### PR TITLE
Fixed typo 'doen't'

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -636,7 +636,7 @@ This call includes an implicit "create/search for document" (in case no document
                                                              // the use case of the check, can be:
                                                              //   interactive =  human user checks own document
                                                              //   batch       =  human user checks many own documents
-                                                             //   baseline    =  a repository of documents is checked, the user doen't own the documents
+                                                             //   baseline    =  a repository of documents is checked, the user doesn't own the documents
                                                              //   automated   =  check of a single document for automated scenarios as for example a git hook
                 "partialCheckRanges": [{ "begin": 10, "end": 20 }, { "begin": 40, "end": 70 }],   // makes the check a partial check
                 "batchId": "gen.clc.159203590",                      // only for batch checks; optional;


### PR DESCRIPTION
I think there is a typo in word 'doen't'. It should be 'doesn't' or 'don't' or 'does not'