### PR TITLE
links in CA dashboard are part of data

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1208,24 +1208,27 @@ Returns the links to the human readable Content Analytics Dashboard, which aggre
 + Response 200 (application/json)
 
         {
-            "links": [
-                {
-                    "linkType": "withoutAccessToken",
-                    "link": "https://tenant.acrolinx.cloud/analytics/dashboard/app/entry/run.jsp?jrd_resext=%7Bactive%3A0%2Creslst%3A%5B%7Bname%3A%22%2FAcrolinxReports%2Fstandard%2FContent+Analysis.dsh%22%2C%22param_page%22%3Afalse%2Cver%3A-1%2C%22dsh_params%22%3A%5B%7B%22jrd_params%22%3A%7B%22BatchId%22%3A%22_nice_batch_id_88-xyz%22%2C%22CsBaseUrl%22%3A%22http%3A%2F%2Flocalhost%3A8031%22%2C%22CsOutputPath%22%3A%22%2Foutput%22%7D%7D%5D%7D%5D%7D&jrd_userinfo=%7B%22prefer%22%3A%7B%22rpt_lang%22%3A%22en%22%2C%22enableNLS%22%3Atrue%7D%7D&jrs.language=en"
-                },
-                {
-                    "linkType": "withAccessToken",
-                    "link": "https://tenant.acrolinx.cloud/analytics/dashboard/app/entry/run.jsp?jrd_resext=%7Bactive%3A0%2Creslst%3A%5B%7Bname%3A%22%2FAcrolinxReports%2Fstandard%2FContent+Analysis.dsh%22%2C%22param_page%22%3Afalse%2Cver%3A-1%2C%22dsh_params%22%3A%5B%7B%22jrd_params%22%3A%7B%22BatchId%22%3A%22_nice_batch_id_88-xyz%22%2C%22CsBaseUrl%22%3A%22http%3A%2F%2Flocalhost%3A8031%22%2C%22CsOutputPath%22%3A%22%2Foutput%22%7D%7D%5D%7D%5D%7D&jrd_userinfo=%7B%22prefer%22%3A%7B%22rpt_lang%22%3A%22en%22%2C%22enableNLS%22%3Atrue%7D%7D&jrs.language=en&apikey=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG11ZCI6ImFjcm9saW54OjA4MTEwYThjNzI3MjQzYTMiLCJuYmYiOjE1MDM5MjcyMzksImlzcyI6ImFjcm9saW54OjA4MTEwYThjNzI3MjQzYTM6NWQyNTQ2NWI5ZTA3NDNiZiIsImV4cCINjYwNTYzOSwidG9rZW5UeXBlIjoidXNlciIsImlhdCI6MTUwNDAxMzYzOSwianRpIjoiMmFmOTQzOWIzZDgyNzMwODAEyMGRiZmRlMmYifQ.Lj0chsnnRTX7IevJNyWMMlCviA6ecYAQ0kacy5EGQz0"
-                },
-                {
-                    "linkType": "shortWithAccessToken",
-                    "link": "http://localhost:8031/api/batch/123?apikey=eyJ0eXAiOiJKV1QiLCOiJhY3JvbGlueCIsInByaXZpbGVnZXMiOlsiQ2hlY2tpbmdBbmRDbGllbnRzLmRvd25sb2FkUmVwb3J0cyJdLCJuYmYiOjE1Mzc5NTQzMjksImlzcyI6ImFjcm9saW54OjA4MTEwYThjNzI3MjQzYTMiLCJleHAiOjE1MzgxMjcxMjksInRva2VuVHlwZSI6InByaXZpbGVnZXMiLCJpYXQi3MjksImp0aSI6IlZRTVNFUzc0SlRCR0JFVFMyWTVBRjJBU1RNIn0.ltac_6JK0s_uODrqrK3TkaUsZiXfrkamo&X-Acrolinx-Client-Locale=en"
-                },
-                {
-                    "linkType": "shortWithoutAccessToken",
-                    "link": "http://localhost:8031/api/batch/123?X-Acrolinx-Client-Locale=en"
-                }
-            ]
+            "links" : {},
+            "data"  : {
+                "links": [
+                    {
+                        "linkType": "withoutAccessToken",
+                        "link": "https://tenant.acrolinx.cloud/analytics/dashboard/app/entry/run.jsp?jrd_resext=%7Bactive%3A0%2Creslst%3A%5B%7Bname%3A%22%2FAcrolinxReports%2Fstandard%2FContent+Analysis.dsh%22%2C%22param_page%22%3Afalse%2Cver%3A-1%2C%22dsh_params%22%3A%5B%7B%22jrd_params%22%3A%7B%22BatchId%22%3A%22_nice_batch_id_88-xyz%22%2C%22CsBaseUrl%22%3A%22http%3A%2F%2Flocalhost%3A8031%22%2C%22CsOutputPath%22%3A%22%2Foutput%22%7D%7D%5D%7D%5D%7D&jrd_userinfo=%7B%22prefer%22%3A%7B%22rpt_lang%22%3A%22en%22%2C%22enableNLS%22%3Atrue%7D%7D&jrs.language=en"
+                    },
+                    {
+                        "linkType": "withAccessToken",
+                        "link": "https://tenant.acrolinx.cloud/analytics/dashboard/app/entry/run.jsp?jrd_resext=%7Bactive%3A0%2Creslst%3A%5B%7Bname%3A%22%2FAcrolinxReports%2Fstandard%2FContent+Analysis.dsh%22%2C%22param_page%22%3Afalse%2Cver%3A-1%2C%22dsh_params%22%3A%5B%7B%22jrd_params%22%3A%7B%22BatchId%22%3A%22_nice_batch_id_88-xyz%22%2C%22CsBaseUrl%22%3A%22http%3A%2F%2Flocalhost%3A8031%22%2C%22CsOutputPath%22%3A%22%2Foutput%22%7D%7D%5D%7D%5D%7D&jrd_userinfo=%7B%22prefer%22%3A%7B%22rpt_lang%22%3A%22en%22%2C%22enableNLS%22%3Atrue%7D%7D&jrs.language=en&apikey=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG11ZCI6ImFjcm9saW54OjA4MTEwYThjNzI3MjQzYTMiLCJuYmYiOjE1MDM5MjcyMzksImlzcyI6ImFjcm9saW54OjA4MTEwYThjNzI3MjQzYTM6NWQyNTQ2NWI5ZTA3NDNiZiIsImV4cCINjYwNTYzOSwidG9rZW5UeXBlIjoidXNlciIsImlhdCI6MTUwNDAxMzYzOSwianRpIjoiMmFmOTQzOWIzZDgyNzMwODAEyMGRiZmRlMmYifQ.Lj0chsnnRTX7IevJNyWMMlCviA6ecYAQ0kacy5EGQz0"
+                    },
+                    {
+                        "linkType": "shortWithAccessToken",
+                        "link": "http://localhost:8031/api/batch/123?apikey=eyJ0eXAiOiJKV1QiLCOiJhY3JvbGlueCIsInByaXZpbGVnZXMiOlsiQ2hlY2tpbmdBbmRDbGllbnRzLmRvd25sb2FkUmVwb3J0cyJdLCJuYmYiOjE1Mzc5NTQzMjksImlzcyI6ImFjcm9saW54OjA4MTEwYThjNzI3MjQzYTMiLCJleHAiOjE1MzgxMjcxMjksInRva2VuVHlwZSI6InByaXZpbGVnZXMiLCJpYXQi3MjksImp0aSI6IlZRTVNFUzc0SlRCR0JFVFMyWTVBRjJBU1RNIn0.ltac_6JK0s_uODrqrK3TkaUsZiXfrkamo&X-Acrolinx-Client-Locale=en"
+                    },
+                    {
+                        "linkType": "shortWithoutAccessToken",
+                        "link": "http://localhost:8031/api/batch/123?X-Acrolinx-Client-Locale=en"
+                    }
+                ]
+            }
         }
 
 # Group User API

--- a/apiary.apib
+++ b/apiary.apib
@@ -1208,8 +1208,8 @@ Returns the links to the human readable Content Analytics Dashboard, which aggre
 + Response 200 (application/json)
 
         {
-            "links" : {},
-            "data"  : {
+            "links": {},
+            "data": {
                 "links": [
                     {
                         "linkType": "withoutAccessToken",


### PR DESCRIPTION
Hi,
I see that response links for CA dashboard are part of data and not directly links. In the response JSON I would prefer them to be displayed as fetched from the platform.

Please correct the formatting if incorrect, I don't have right configured tool to update documentation.

Thanks
Abhijeet