### PR TITLE
danielroca-fixes

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1608,7 +1608,7 @@ Publishes a new notification on the platform.
         {
             "title": "Important Announcement",                               // required; The title of the notification
             "body":  "Acrolinx Platform 5.6 will be deployed tomorrow.",     // required; Notification text.
-            "importance": "HIGH",                                            // optional; "HIGH"|"NORMAL"
+            "importance": "high",                                            // optional; "high"|"normal"
             "start": 1528127782,                                             // required; Notification start time (epoch millisecond timestamp)
             "end": 1530719782                                               // required; Notification end time (epoch millisecond timestamp)
         }
@@ -1639,7 +1639,7 @@ Retrieves active notifications from the platform.
               "id": "e06491e9-c67f-4da7-85da-eb30b9ca9101",
               "title": "Important Announcement",
               "body":  "Acrolinx Platform 5.6 will be deployed tomorrow.",
-              "importance": "HIGH",
+              "importance": "high",
               "start": 1528127782,
               "end": 1530719782
               }


### PR DESCRIPTION
According to the blueprint the field importance it's an optional field that takes "HIGH" or "NORMAL", but it actually is an optional field that takes null, and lowercase "normal" or "high", also the behaviour if the field is set to null is not documented. This PR only addresses the casing issue.