### PR TITLE
DEV-25720 set password length limit to 1

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1499,7 +1499,7 @@ Returns information about the current user. See below for possible responses.
 
 - Username must be unique and cannot exceed 255 characters
 - Full name field cannot exceed 255 characters (optional)
-- Password must be between 10 and 128 characters (optional)
+- Password must be between 1 and 128 characters (optional)
 - License type must be one of 'named' or 'concurrent'
 - Must have `UserAndRoles.editUser` privileges to perform this request
 
@@ -1512,7 +1512,7 @@ Returns information about the current user. See below for possible responses.
     + Attributes (object)
         + username (string) - The unique username, max length 255 characters
         + fullName (string) - The full name of the user, max length 255 characters (optional)
-        + password (string) - The user password, length between 10 and 128 characters (optional)
+        + password (string) - The user password, length between 1 and 128 characters (optional)
         + licenseType (string) - Indicates the type of license as one of ['named' | 'concurrent']
     
     + Body
@@ -1594,7 +1594,7 @@ Returns information about the current user. See below for possible responses.
                         "title": "Validation error",
                         "constraint": "Size",
                         "attributePath": "password",
-                        "detail": "size must be between 10 and 128",
+                        "detail": "size must be between 1 and 128",
                         "invalidValue": "simple"
                     }
                 ],
@@ -1688,7 +1688,7 @@ Returns information about the current user. See below for possible responses.
     + Attributes (object)
         + username (string) - The unique username, max length 255 characters
         + fullName (string) - The full name of the user, max length 255 characters (optional)
-        + password (string) - The user password, length between 10 and 128 characters (optional)
+        + password (string) - The user password, length between 1 and 128 characters (optional)
         + licenseType (string) - Indicates the type of license as one of ['named' | 'concurrent']
         + roles (array[Role]) - List of assignable roles (optional)
     
@@ -1786,7 +1786,7 @@ Returns information about the current user. See below for possible responses.
                         "title": "Validation error",
                         "constraint": "Size",
                         "attributePath": "password",
-                        "detail": "size must be between 10 and 128",
+                        "detail": "size must be between 1 and 128",
                         "invalidValue": "simple"
                     }
                 ],


### PR DESCRIPTION
- Set the password length limit to 1 (Used to be 10)
- Please read JIRA ticket comments for further notes and rationale