### PR TITLE
DEV-22511: add licenses api group with statistics sub-section

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3211,7 +3211,7 @@ Details of the statistics attributes in the table below:
 | `named`      | licensed      | Total number of licenses      |
 | `named`      | active        | Total active licenses         |
 | `named`      | inactive      | Total inactive licenses       |
-| `named`      | available     | Total available licenses (`licensed` - `active`) |
+| `named`      | available     | Total available licenses (`licensed` minus `active`) |
 | `concurrent` | licensed      | Total number of licenses      |
 | `concurrent` | existing      | Total number of licenses used |
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3220,20 +3220,25 @@ Details of the statistics attributes in the table below:
 
 + Response 200 (application/json)
 
-    + Attributes (LicenseStatistics)
+    + Attributes (object)
+        + links (object)
+        + data(LicenseStatistics)
 
     + Body
 
             {
-                "named": {
-                    "licensed": 150,
-                    "active": 58,
-                    "inactive": 23,
-                    "available": 92
-                },
-                "concurrent": {
-                    "licensed": 50,
-                    "existing": 10
+                "links": {},
+                "data": {
+                    "named": {
+                        "licensed": 150,
+                        "active": 58,
+                        "inactive": 23,
+                        "available": 92
+                    },
+                    "concurrent": {
+                        "licensed": 50,
+                        "existing": 10
+                    }
                 }
             }
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3185,6 +3185,68 @@ noted in the Create User API section.
             }
         }
 
+# Group Licenses API
+
+TODO : Description for this api group
+
+## Statistics [/api/v1/licenses/statistics]
+
+### Get License Statistics for Users [GET]
+
+TODO: What this method does.
+Privs `UserAndRoles.read`
+
+**Note:**
+- note 1
+- note 2
+- note 3
+
++ Response 200 (application/json)
+
+    + Attributes (LicenseStatistics)
+
+    + Body
+
+            {
+                "named": {
+                    "licensed": 150,
+                    "active": 58,
+                    "inactive": 23,
+                    "available": 92
+                },
+                "concurrent": {
+                    "licensed": 50,
+                    "existing": 10
+                }
+            }
+
++ Response 401 (application/json)
+
+        // When the access token is missing or is invalid in the request
+        {
+            "links": {},
+            "error": {
+                "detail": "Valid authentication has either not been provided or is insufficient.",
+                "type": "auth",
+                "title": "Invalid authentication",
+                "status": 401
+            }
+        }
+
++ Response 403 (application/json)
+
+        // when there is insufficient privileges to fetch license statistics
+        {
+        "links": {},
+            "error": {
+                "detail": "The user does not have the required privileges to perform the operation.",
+                "type": "insufficientPrivileges",
+                "title": "Insufficient privileges",
+                "status": 403
+            }
+        }
+
+
 # Group Role API
 
 Here, a role is an entity that has an id, a name and list of privileges and information whether this role is a default role. 
@@ -4820,3 +4882,17 @@ Debug API:
 ## BulkResultResponse (object)
 + results (array[BulkResult])
 + errors (array[BulkError])
+
+## LicenseStatistics
++ named (Named)
++ concurrent (Concurrent)
+
+### Named
++ licensed (number) - The total number of named licenses available
++ active (number) - The number of active named users
++ inactive (number) - The number of inactive named users
++ available (number) - The numer of avialable licenses (licensed - active)
+
+### Concurrent
++ licensed (number) - The total number of concurrent licenses available
++ existing (number) - The number of concurrent lincenses used

--- a/apiary.apib
+++ b/apiary.apib
@@ -3194,15 +3194,17 @@ License information is provided by the following set of APIs.
 ### Get License Statistics for Users [GET]
 
 Returns license statistics for the running instance showing the sum of license types `named` and `concurrent`.
-The Built-in users such as `Admin`, `TermBrowser`, `TermTargetAccess`, `TermContribution`, `TermApiAccess` and `AnalyticsReadOnlyUser`
-are included in the statistics calculation along with all the non-builtin users, however the following conditions are checked
-that will ultimately decide the user to be included in the calculation:
+The following conditions are checked for all users in order to qualify them to be included in the calculation:
 
 - Must be one of the following License Types `named` or `concurrent`
-- For `named` license they must be activated for `Checking` session type
-- For `named` license they must not be free of charge
+- For `named` license they must be active it must satisfy the following
+    - Be activated for `Checking` session type
+    - Must not be free of charge
 - All other `named` licensed users will be considered `inactive`
 - All `concurrent` licensed users will be `existing` if a license exists
+
+**Note:** Builtin users such as `Admin`, `TermBrowser`, `TermTargetAccess`, `TermContribution`, `TermApiAccess` and `AnalyticsReadOnlyUser`
+are included in the statistics calculation along with all the non-builtin users but are subject to the conditions above.
 
 Details of the statistics attributes in the table below:
 
@@ -3259,7 +3261,7 @@ Details of the statistics attributes in the table below:
 
         // when there is insufficient privileges to fetch license statistics
         {
-        "links": {},
+            "links": {},
             "error": {
                 "detail": "The user does not have the required privileges to perform the operation.",
                 "type": "insufficientPrivileges",
@@ -3267,7 +3269,6 @@ Details of the statistics attributes in the table below:
                 "status": 403
             }
         }
-
 
 # Group Role API
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3219,6 +3219,7 @@ Details of the statistics attributes in the table below:
 
 **Note:**
 - Must have `UserAndRoles.editUser` privileges to perform this request
+- Concurrent license numbers may be seen (non-zero) if a license has been configured for both `named` and `concurrent` user limits
 
 + Response 200 (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3187,19 +3187,36 @@ noted in the Create User API section.
 
 # Group Licenses API
 
-TODO : Description for this api group
+License information is provided by the following set of APIs.
 
 ## Statistics [/api/v1/licenses/statistics]
 
 ### Get License Statistics for Users [GET]
 
-TODO: What this method does.
-Privs `UserAndRoles.read`
+Returns license statistics for the running instance showing the sum of license types `named` and `concurrent`.
+The Built-in users such as `Admin`, `TermBrowser`, `TermTargetAccess`, `TermContribution`, `TermApiAccess` and `AnalyticsReadOnlyUser`
+are included in the statistics calculation along with all the non-builtin users, however the following conditions are checked
+that will ultimately decide the user to be included in the calculation:
+
+- Must be one of the following License Types `named` or `concurrent`
+- For `named` license they must be activated for `Checking` session type
+- For `named` license they must not be free of charge
+- All other `named` licensed users will be considered `inactive`
+- All `concurrent` licensed users will be `existing` if a license exists
+
+Details of the statistics attributes in the table below:
+
+| License Type | Sum Attribute | Description                   |
+|:-------------|---------------|-------------------------------|
+| `named`      | licensed      | Total number of licenses      |
+| `named`      | active        | Total active licenses         |
+| `named`      | inactive      | Total inactive licenses       |
+| `named`      | available     | Total available licenses (`licensed` - `active`) |
+| `concurrent` | licensed      | Total number of licenses      |
+| `concurrent` | existing      | Total number of licenses used |
 
 **Note:**
-- note 1
-- note 2
-- note 3
+- Must have `UserAndRoles.editUser` privileges to perform this request
 
 + Response 200 (application/json)
 


### PR DESCRIPTION
Add a new section for the `/licenses` end-point with a subsection on statistics.