### PR TITLE
Added info about pagination

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1302,6 +1302,34 @@ So that the `+` character encoded to `%2B` stays valid, make sure that the query
 with [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent). 
 Alternatively, you can always leave out the `+` character as it will default to ascending order.
 
+**Pagination**
+
+Instead of getting the entire list of users, you can also request a paginated
+response by adding two query parameters, `page` and `per_page`. Setting `page`
+is required, counting of pages starts at `1`. By default, `per_page` is set to
+`10`, so this parameter is optional.
+
+In case a paginated response is requested, a couple of header values will be added:
+
+| Header                     | Description                                     |
+|----------------------------|-------------------------------------------------|
+| `X-Acrolinx-Page`          | The index of the current page, starting at `1`. |
+| `X-Acrolinx-Next-Page`     | The index of the next page.                     |
+| `X-Acrolinx-Previous-Page` | The index of the previous page.                 |
+| `X-Acrolinx-Total-Pages`   | The total number of pages.                      |
+| `X-Acrolinx-Total`         | The total number of items.                      |
+
+In addition to the header values, the response object contains a couple of URLs
+within the `links` object:
+
+| Relation | Description                       |
+|----------|-----------------------------------|
+| `next`   | The URL to get the next page.     |
+| `prev`   | The URL to get the previous page. |
+| `first`  | The URL to get the first page.    |
+| `last`   | The URL to get the last page.     |
+
+
 + Request Get a list of all users (application/json)
 
 + Parameters

--- a/apiary.apib
+++ b/apiary.apib
@@ -1329,6 +1329,8 @@ within the `links` object:
 | `first`  | The URL to get the first page.    |
 | `last`   | The URL to get the last page.     |
 
+The example response contains the pagination URLs in the `links` object to show
+what can be expected.
 
 + Request Get a list of all users (application/json)
 
@@ -1351,6 +1353,10 @@ within the `links` object:
             + `licenseType`
             + `licenseStatus`
 
+    + page (number, optional) - Optional query parameter for pagination
+    + per_page (number, optional) - Optional query parameter for sizing a page
+      + Default: `10`
+
 + Response 200 (application/json)
 
     + Attributes (object)
@@ -1360,7 +1366,12 @@ within the `links` object:
     + Body
 
             {
-                "links": {},
+                "links": {
+                    "prev": "https://tenant.acrolinx.cloud/api/v1/user?page=2&per_page=2",
+                    "next": "https://tenant.acrolinx.cloud/api/v1/user?page=4&per_page=2",
+                    "first": "https://tenant.acrolinx.cloud/api/v1/user?page=1&per_page=2",
+                    "last": "https://tenant.acrolinx.cloud/api/v1/user?page=60&per_page=2"
+                },
                 "data": [
                     {
                         "id": "eb323701-839f-4998-b56e-3e20c70259c5",

--- a/apiary.apib
+++ b/apiary.apib
@@ -1281,7 +1281,7 @@ This request returns information about the current user. The information include
 
 ## User Resource [/api/v1/user]
 
-### Get All Users [GET /api/v1/user{?sort}]
+### Get All Users [GET /api/v1/user{?sort,page,per_page}]
 
 This request retrieves a list of all users in the order that they were added.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1355,12 +1355,12 @@ what can be expected.
 
     + page (number, optional) - Optional query parameter for pagination
     + per_page (number, optional) - Optional query parameter for sizing a page
-      + Default: `10`
+        + Default: `10`
 
 + Response 200 (application/json)
 
     + Attributes (object)
-        + links (object)
+        + links (Pagination)
         + data (array[User])
     
     + Body
@@ -5052,3 +5052,9 @@ Debug API:
 ### Concurrent
 + licensed (number) - The total number of concurrent licenses available
 + existing (number) - The number of concurrent lincenses used
+
+### Pagination
++ prev (string) - URI of the previous page
++ next (string) - URI of the next page
++ first (string) - URI of the first page
++ last  (string) - URI of the last page


### PR DESCRIPTION
I've added information about how to get a paginated response for the user list and how the response is affected. I've only added two tables about added header values and links relations. I did not add another complete response example since I feel that would bloat the docs. The tables are concise and should contain all required information.