### PR TITLE
DEV-26948 Add missing auth headers to requests

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -503,6 +503,13 @@ If the server runs in Targets Mode, the goals contain an additional string field
 `required` (meaning this goal will be included in the calculation of the overall score so it is required to take this goal into account
 when creating content) or `recommended` (meaning this goal is a recommendation only and does not count towards the overall document score).
 
++ Request
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+            X-Acrolinx-Client: your_client_signature
+
 + Response 200 (application/json)
 
         {
@@ -600,63 +607,69 @@ The same information is available in the checking capabilities.
 
 + Request (application/json)
 
+    + Headers
 
-        A minimal request declaring the format only:
+            X-Acrolinx-Auth: your_access_token
+            X-Acrolinx-Client: your_client_signature
 
-        {
-            "content": "text to check",                  // required
-            "checkOptions": {
-                "contentFormat": "markdown",                 // optional, default: auto
-            },
-        }
+    + Body
 
-        A minimal request using a document reference to tell the format:
+            // A minimal request declaring the format only:
 
-        {
-            "content": "text to check",                  // required
-            "document": {                                // optional, default: empty "document" object
-                "reference": "C:\\abc.md",              // optional, used to determine the input format and correlate multiple checks of the same document
+            {
+                "content": "text to check",                  // required
+                "checkOptions": {
+                    "contentFormat": "markdown",                 // optional, default: auto
+                },
             }
-        }
+
+            // A minimal request using a document reference to tell the format:
+
+            {
+                "content": "text to check",                  // required
+                "document": {                                // optional, default: empty "document" object
+                    "reference": "C:\\abc.md",              // optional, used to determine the input format and correlate multiple checks of the same document
+                }
+            }
 
 
-        If a standard format is configured on the server, the minimal request is even shorter:
+            // If a standard format is configured on the server, the minimal request is even shorter:
 
-        {
-            "content": "text to check",                  // required
-        }
+            {
+                "content": "text to check",                  // required
+            }
 
-        A request can be much more specific, this is the full set of attributes:
+            // A request can be much more specific, this is the full set of attributes:
 
-        {
-            "content": "text to check",                  // required
-            "contentEncoding": "base64",             // optional, default: none = HTTP request encoding
-            "checkOptions": {
-                "guidanceProfileId": "aud-1",                       // optional, default: first guidance profile
-                "reportTypes": ["scorecard"],  // optional, default: scorecard
-                "contentFormat": "markdown",                 // optional, default: auto
-                "checkType": "batch",                        // optional, default: interactive
-                                                             // the use case of the check, can be:
-                                                             //   interactive =  human user checks own document
-                                                             //   batch       =  human user checks many own documents
-                                                             //   baseline    =  a repository of documents is checked, the user doesn't own the documents
-                                                             //   automated   =  check of a single document for automated scenarios as for example a git hook
-                "partialCheckRanges": [{ "begin": 10, "end": 20 }, { "begin": 40, "end": 70 }],   // makes the check a partial check
-                "batchId": "gen.clc.159203590"                      // only for batch checks; optional;
-            },
-            "document": {                                // optional, default: empty "document" object
-                "reference": "C:\\abc.md",              // optional client known id hint e.g. a file name
-                "customFields": [                       // optional
-                    {
-                        "key": "field1",
-                        "value": "value1"
-                    },{
-                        "key": "field2",
-                        "value": "value2"
-                    }
-                ]
-             }
-        }
+            {
+                "content": "text to check",                  // required
+                "contentEncoding": "base64",             // optional, default: none = HTTP request encoding
+                "checkOptions": {
+                    "guidanceProfileId": "aud-1",                       // optional, default: first guidance profile
+                    "reportTypes": ["scorecard"],  // optional, default: scorecard
+                    "contentFormat": "markdown",                 // optional, default: auto
+                    "checkType": "batch",                        // optional, default: interactive
+                                                                 // the use case of the check, can be:
+                                                                 //   interactive =  human user checks own document
+                                                                 //   batch       =  human user checks many own documents
+                                                                 //   baseline    =  a repository of documents is checked, the user doesn't own the documents
+                                                                 //   automated   =  check of a single document for automated scenarios as for example a git hook
+                    "partialCheckRanges": [{ "begin": 10, "end": 20 }, { "begin": 40, "end": 70 }],   // makes the check a partial check
+                    "batchId": "gen.clc.159203590"                      // only for batch checks; optional;
+                },
+                "document": {                                // optional, default: empty "document" object
+                    "reference": "C:\\abc.md",              // optional client known id hint e.g. a file name
+                    "customFields": [                       // optional
+                        {
+                            "key": "field1",
+                            "value": "value1"
+                        },{
+                            "key": "field2",
+                            "value": "value2"
+                        }
+                    ]
+                 }
+            }
 
 + Response 201 (application/json)
 
@@ -705,6 +718,13 @@ Note that not all occurrences of an issue always have the same suggestions. In t
 ### Poll Check Result [GET]
 
 Polls the check result. Either a progress or the completed result is returned. The URL for the request is found in the submitted check's "result" link.
+
++ Request
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+            X-Acrolinx-Client: your_client_signature
 
 + Parameters
     + id: `AB-153` (required, string) ... the check id
@@ -1217,8 +1237,15 @@ Polls the check result. Either a progress or the completed result is returned. T
 
         Cancels a check. Users can only cancel checks they submitted. The URL for the request is found in the submitted check's "cancel" link.
 
-+ Parameters
-   + id: `153` (required, number) ... the check id
++ Request
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+            X-Acrolinx-Client: your_client_signature
+
+    + Parameters
+        + id: `153` (required, number) ... the check id
 
 
 + Response 200 (application/json)
@@ -1234,8 +1261,15 @@ Polls the check result. Either a progress or the completed result is returned. T
 
 Returns the links to the human readable Content Analytics Dashboard, which aggregates information of all checks belonging to the given batch id. Requires the Reporting.read privilege. The link with API token contains a new privilege token with the right Reporting.read.
 
-+ Parameters
-    + batchId: `XYZ-10-22-33` (required, string) ... the batch check id
++ Request
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+            X-Acrolinx-Client: your_client_signature
+
+    + Parameters
+        + batchId: `XYZ-10-22-33` (required, string) ... the batch check id
 
 + Response 200 (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -719,15 +719,15 @@ Note that not all occurrences of an issue always have the same suggestions. In t
 
 Polls the check result. Either a progress or the completed result is returned. The URL for the request is found in the submitted check's "result" link.
 
++ Parameters
+    + id: `AB-153` (required, string) - the check id
+
 + Request
 
     + Headers
 
             X-Acrolinx-Auth: your_access_token
             X-Acrolinx-Client: your_client_signature
-
-+ Parameters
-    + id: `AB-153` (required, string) ... the check id
 
 + Response 202 (application/json)
 
@@ -1237,16 +1237,15 @@ Polls the check result. Either a progress or the completed result is returned. T
 
         Cancels a check. Users can only cancel checks they submitted. The URL for the request is found in the submitted check's "cancel" link.
 
++ Parameters
+    + id: `AB-153` (required, string) - the check id
+
 + Request
 
     + Headers
 
             X-Acrolinx-Auth: your_access_token
             X-Acrolinx-Client: your_client_signature
-
-    + Parameters
-        + id: `153` (required, number) ... the check id
-
 
 + Response 200 (application/json)
 
@@ -1261,6 +1260,9 @@ Polls the check result. Either a progress or the completed result is returned. T
 
 Returns the links to the human readable Content Analytics Dashboard, which aggregates information of all checks belonging to the given batch id. Requires the Reporting.read privilege. The link with API token contains a new privilege token with the right Reporting.read.
 
+    + Parameters
+        + batchId: `XYZ-10-22-33` (required, string) - the batch check id
+
 + Request
 
     + Headers
@@ -1268,8 +1270,6 @@ Returns the links to the human readable Content Analytics Dashboard, which aggre
             X-Acrolinx-Auth: your_access_token
             X-Acrolinx-Client: your_client_signature
 
-    + Parameters
-        + batchId: `XYZ-10-22-33` (required, string) ... the batch check id
 
 + Response 200 (application/json)
 
@@ -1308,10 +1308,6 @@ You’re _required_ to provide user information for the following:
 Security:
 * A user can read and update its own data.
 * Only privileged users (admin, for example) can read or update other users' data.
-
-## Current User [/api/v1/user/self]
-
-This request returns information about the current user. The information includes the user id, username, the user’s full name, the date the user was created, the last time the user accessed the integration, checking frequency, tenant ID, token ID, license type, and license status. You’ll also see properties, roles, and custom fields.
 
 ## User Resource [/api/v1/user]
 
@@ -1550,14 +1546,19 @@ what can be expected.
 
 ### Get a User [GET /api/v1/user/{id}]
 
+This request returns information about an user. 
+The information includes the user id, username, the user’s full name, the date the user was created, the last time the user accessed the integration, checking frequency, tenant ID, token ID, license type, and license status. 
+You’ll also see properties, roles, and custom fields.
+
++ Parameters
+
+    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
+
 + Request Get specified user by id (application/json)
 
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-+ Parameters
-    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
 
 + Response 200 (application/json)
 
@@ -1632,6 +1633,94 @@ what can be expected.
                 "type": "insufficientPrivileges",
                 "title": "Insufficient privileges",
                 "status": 403
+            }
+        }
+
++ Response 404 (application/json)
+
+        // when the user couldn’t be identified by its *id* in the database
+        {
+        "links": {},
+            "error": {
+                "reference": "652b5c86-de20-4629-9df6-84265f2722ec",
+                "detail": "An unspecific client error occurred.",
+                "type": "client",
+                "title": "Not Found",
+                "status": 404
+            }
+        }
+
+
+### Get a User (Self) [GET /api/v1/user/self]
+
+This is an alternative way of getting information about the current (in request authorized) user. 
+
++ Request Get current user (application/json)
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
++ Response 200 (application/json)
+
+    + Attributes (object)
+        + links (object)
+        + data (User)
+    
+    + Body
+
+            {
+                "links": {},
+                "data": {
+                    "id": "eb323701-839f-4998-b56e-3e20c70259c5",
+                    "username": "fred",
+                    "fullName": "Fred Freelancer",
+                    "createdOn": "2021-04-15T15:00:26.495Z",
+                    "lastIntegrationAccess": "1970-01-01T00:00:00Z",
+                    "licenseType": "named",
+                    "licenseStatus": "inactive",
+                    "tenantId": "smarttech",
+                    "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
+                    "checkingFrequency": "infrequent",
+                    "properties" : {
+                        "customkey": "customvalue",
+                    },
+                    "roles": [
+                        {
+                            "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
+                            "name": "Term Contributor",
+                            "privileges": []
+                        },
+                        {
+                            "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
+                            "name": "Term Browser Administrator",
+                            "privileges": []
+                        }
+                    ],
+                    "customFields": [
+                        {
+                            "key": "Department",
+                            "displayName": "Department",
+                            "inputType": "optional",
+                            "type": "list",
+                            "value": "Example Department",
+                            "possibleValues": [
+                                "Example Department"
+                            ]
+                        }
+                    ]
+                }
+            }
+
++ Response 401 (application/json)
+
+        // when the access token in the request is missing or invalid
+        {
+            "error": {
+                "detail": "Valid authentication has either not been provided or is insufficient.",
+                "type": "auth",
+                "title": "Invalid authentication",
+                "status": 401
             }
         }
 
@@ -2219,7 +2308,7 @@ what can be expected.
 ### Update a User [PUT /api/v1/user/{id}]
 
 + Parameters
-    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
+    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
 
 + Request Update fullName attribute (application/json)
 
@@ -2233,9 +2322,6 @@ what can be expected.
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID
 
     + Attributes (object)
         + fullName (string, required)
@@ -2345,9 +2431,6 @@ what can be expected.
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID
 
     + Attributes (object)
         + roles (array[Role], required)
@@ -2711,14 +2794,14 @@ This method deletes a specified user based on its *id*.
 
 To read more about managing users and built-in users, see [Manage Your Users](https://docs.acrolinx.com/coreplatform/latest/en/user-management/manage-your-users) in the Acrolinx documentation.
 
++ Parameters
+    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
+
 + Request Delete user by id
 
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
 
 + Response 204
 
@@ -2916,16 +2999,16 @@ Typical use cases for this API:
 **Alternative use case:** Create an API token to impersonate a user
 
     Sometimes an admin might want to impersonate a user to help troubleshoot. 
-    If a user comes across a bug, for example, an admin may want to impersonate the user to try and duplicate the problem.   
+    If a user comes across a bug, for example, an admin may want to impersonate the user to try and duplicate the problem.
+
++ Parameters
+    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
 
 + Request Create an API token for someone by user id
 
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
 
 + Response 200 (application/json)
 
@@ -3002,7 +3085,7 @@ This method uses the *id* to release an active license consumed by a user.
             X-Acrolinx-Auth: your_access_token
 
     + Parameters
-        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
+        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
 
 + Response 204
 
@@ -4080,14 +4163,14 @@ This lets you add new roles.
 
 This returns a role that was identified by its *id* in the database.
 
++ Parameters
+    + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) - UUID of the role, unique identifier
+
 + Request
 
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
 + Response 200 (application/json)
 
@@ -4147,6 +4230,9 @@ This lets you update a role that was identified by its *id* in the database.
     - Acrolinx comes with a number of preconfigured roles that are common in many organizations that use Acrolinx. 
 - You can use one request to update role attributes individually or completely. The request will ignore missing attributes or attributes with `null` values.
 
++ Parameters
+    + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) - UUID of the role, unique identifier
+
 + Request Update entire model (application/json)
 
     You can use one request to update all attributes of a role.
@@ -4156,9 +4242,6 @@ This lets you update a role that was identified by its *id* in the database.
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
     + Attributes (CreateOrUpdateRole)
 
@@ -4233,9 +4316,6 @@ This lets you update a role that was identified by its *id* in the database.
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
     + Attributes (object)
         + name (string, required)
@@ -4384,9 +4464,6 @@ This lets you update a role that was identified by its *id* in the database.
 
             X-Acrolinx-Auth: your_access_token
 
-    + Parameters
-        + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
-
     + Attributes (object)
         + privileges (array[string], required)
 
@@ -4533,9 +4610,6 @@ This lets you update a role that was identified by its *id* in the database.
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
     + Attributes (object)
         + default (boolean, required) - Possible values are 'true' or 'false'

--- a/apiary.apib
+++ b/apiary.apib
@@ -445,14 +445,14 @@ privileges and identity owned by the user that signed in.
 
 When polling returned a final result, the polling endpoint will disappear and return a `NOT FOUND` status.
 
++ Parameters
+    + id: `99576707-ed8c-44b6-82b8-c3ced8f349d1` (string, required) - poll-id for the authorization request
+
 + Request
 
     + Header
 
             X-Acrolinx-Client: QWxlU2hNyb2bHVnLWlunhQyR29Rm9xpbvZ2lZXRz; 1.0.1.45
-
-+ Parameters
-    + id: `99576707-ed8c-44b6-82b8-c3ced8f349d1` (string, required) - poll-id for the authorization request
 
 + Response 200 (application/json)
    A user has completed the sign-in process and the server has created a new access token.
@@ -1260,8 +1260,8 @@ Polls the check result. Either a progress or the completed result is returned. T
 
 Returns the links to the human readable Content Analytics Dashboard, which aggregates information of all checks belonging to the given batch id. Requires the Reporting.read privilege. The link with API token contains a new privilege token with the right Reporting.read.
 
-    + Parameters
-        + batchId: `XYZ-10-22-33` (required, string) - the batch check id
++ Parameters
+    + batchId: `XYZ-10-22-33` (required, string) - the batch check id
 
 + Request
 
@@ -1362,13 +1362,6 @@ within the `links` object:
 The example response contains the pagination URLs in the `links` object to show
 what can be expected.
 
-+ Request Get a list of all users (application/json)
-
-    + Headers
-
-            X-Acrolinx-Auth: your_access_token
-
-
 + Parameters
 
     + sort (enum[string], optional) - Optional query parameter for sorting by an attribute. 
@@ -1391,6 +1384,12 @@ what can be expected.
     + page (number, optional) - Optional query parameter for pagination
     + per_page (number, optional) - Optional query parameter for sizing a page
         + Default: `10`
+
++ Request Get a list of all users (application/json)
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
 + Response 200 (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3473,6 +3473,12 @@ To read more about role-based access control in Acrolinx, see the [Acrolinx role
 
 Returns a list of all roles including the associated privileges.
 
++ Request
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
 + Response 200 (application/json)
 
     + Attributes (object)
@@ -3628,6 +3634,12 @@ This returns a list of all supported privileges.
 In newer platform releases, there are rare instances where privileges might be introduced or removed. 
 To find out which privileges come with your installation, submit this request and compare it to the example response.  
 
++ Request
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
 + Response 200 (application/json)
 
     + Attributes (object)
@@ -3730,6 +3742,10 @@ This lets you add new roles.
 
 
 + Request Create a role (application/json)
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
     + Attributes (CreateOrUpdateRole)
 
@@ -3876,6 +3892,10 @@ This lets you add new roles.
         }
 
 + Request Create a default role (application/json)
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
     + Attributes (CreateOrUpdateRole)
 
@@ -4026,8 +4046,14 @@ This lets you add new roles.
 
 This returns a role that was identified by its *id* in the database.
 
-+ Parameters
-    + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
++ Request
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
+    + Parameters
+        + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
 + Response 200 (application/json)
 
@@ -4093,7 +4119,11 @@ This lets you update a role that was identified by its *id* in the database.
 
     **Note:** Check the other request examples to see how to update individual attributes and validations.
 
-     + Parameters
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
+    + Parameters
         + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
     + Attributes (CreateOrUpdateRole)
@@ -4165,6 +4195,10 @@ This lets you update a role that was identified by its *id* in the database.
 
     **Note:**
     - The name needs to be unique and must be between 1 and 254 characters.
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
     + Parameters
         + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
@@ -4312,6 +4346,10 @@ This lets you update a role that was identified by its *id* in the database.
     **Warning:** This action **permanently** updates the privileges that belong to a role. 
     When you change the privileges for a role, all users with that role will get the updated set of privileges.
 
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
     + Parameters
         + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
@@ -4458,6 +4496,10 @@ This lets you update a role that was identified by its *id* in the database.
     **Note:**
     - You can have multiple default roles.
 
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
     + Parameters
         + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
@@ -4540,6 +4582,10 @@ This lets you update a role that was identified by its *id* in the database.
     **Note:**
     - You aren’t required to have default roles.
 
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
     + Parameters
         + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
 
@@ -4609,6 +4655,12 @@ This lets you delete a specified role based on its *id*.
 - The role isn’t a preconfigured built-in role such as "Author", "Super Administrator", or "Term Browser".
 - The role isn’t selected as a default role.
 - The role isn’t currently assigned to one or more users.
+
++ Request Delete by id
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
 + Response 204 (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3078,14 +3078,14 @@ This method uses the *id* to release an active license consumed by a user.
 
 **Result:** User's `licenseStatus` changed from `active` to `inactive`.
 
++ Parameters
+    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
+
 + Request Release an Active Named User License by user id
 
     + Headers
 
             X-Acrolinx-Auth: your_access_token
-
-    + Parameters
-        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
 
 + Response 204
 
@@ -4694,9 +4694,6 @@ This lets you update a role that was identified by its *id* in the database.
 
             X-Acrolinx-Auth: your_access_token
 
-    + Parameters
-        + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) ... UUID
-
     + Attributes (object)
         + default (boolean, required) - Possible values are 'true' or 'false'
 
@@ -4763,6 +4760,9 @@ This lets you delete a specified role based on its *id*.
 - The role isn’t a preconfigured built-in role such as "Author", "Super Administrator", or "Term Browser".
 - The role isn’t selected as a default role.
 - The role isn’t currently assigned to one or more users.
+
++ Parameters
+    + id: `f608876c-a943-4ad2-82c1-e59df943ce41` (required, string) - UUID of the role, unique identifier
 
 + Request Delete by id
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1334,6 +1334,11 @@ what can be expected.
 
 + Request Get a list of all users (application/json)
 
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
+
 + Parameters
 
     + sort (enum[string], optional) - Optional query parameter for sorting by an attribute. 
@@ -1513,6 +1518,10 @@ what can be expected.
 
 + Request Get specified user by id (application/json)
 
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
 + Parameters
     + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
 
@@ -1629,6 +1638,10 @@ what can be expected.
      This will create a new user if you add a username, fullName, and password to the request. 
 
     **Note:** By default, Acrolinx will automatically assign the user the license type `named` and the role `Author`.
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
     + Attributes (CreateUser)
     
@@ -1805,6 +1818,10 @@ what can be expected.
     This request will create a new user with the `named` license type explicitly specified in the request model. 
     
     **Note:** Acrolinx will automatically assign the default role `Author` to the user.
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
     + Attributes (CreateUser)
 
@@ -2179,6 +2196,10 @@ what can be expected.
     **Note:**
     - You can delete the `fullName` by changing the attribute to empty.
 
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
     + Parameters
         + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID
 
@@ -2286,6 +2307,10 @@ what can be expected.
     You can update a user’s role.
 
     In this example, only the `roles` attribute will change for the user `fred`. This was identified in the database by its *id*. Each user needs at least one assigned role. This doesn’t apply to built-in users. You can only grant privileges that you yourself have (privilege escalation). If you add a role that doesn’t exist, the call will fail and the error message will show the unknown roles that were referenced.
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
     + Parameters
         + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID
@@ -2411,6 +2436,10 @@ what can be expected.
 
 + Request Set a custom field (application/json)
 
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
     + Attributes (object)
         + customFields (array[CustomField])
 
@@ -2491,6 +2520,10 @@ what can be expected.
             }
 
 + Request Clear a custom field (application/json)
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
     + Attributes (object)
         + customFields (array[CustomField])
@@ -2644,8 +2677,14 @@ This method deletes a specified user based on its *id*.
 
 To read more about managing users and built-in users, see [Manage Your Users](https://docs.acrolinx.com/coreplatform/latest/en/user-management/manage-your-users) in the Acrolinx documentation.
 
-+ Parameters
-    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
++ Request Delete user by id
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
+    + Parameters
+        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
 
 + Response 204
 
@@ -2845,8 +2884,14 @@ Typical use cases for this API:
     Sometimes an admin might want to impersonate a user to help troubleshoot. 
     If a user comes across a bug, for example, an admin may want to impersonate the user to try and duplicate the problem.   
 
-+ Parameters
-    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
++ Request Create an API token for someone by user id
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
+    + Parameters
+        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
 
 + Response 200 (application/json)
 
@@ -2916,8 +2961,14 @@ This method uses the *id* to release an active license consumed by a user.
 
 **Result:** User's `licenseStatus` changed from `active` to `inactive`.
 
-+ Parameters
-      + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
++ Request Release an Active Named User License by user id
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
+    + Parameters
+        + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) ... UUID of the user, unique identifier
 
 + Response 204
 
@@ -3011,6 +3062,7 @@ The header parameters are set as follows:
     + Headers
 
             Accept: text/csv
+            X-Acrolinx-Auth: your_access_token
 
 + Response 200 (text/csv)
 
@@ -3061,6 +3113,7 @@ The header parameters are set as follows:
     + Headers
 
             Accept: text/html
+            X-Acrolinx-Auth: your_access_token
 
 + Response 406
 
@@ -3096,6 +3149,10 @@ noted in the Create User API section.
     This request lets you create 5 new users by specifying some basic fields (`username`, `fullName`, `password`) in the request model.
 
     **Note:** Acrolinx will assign a license type and role automatically. These are typically the license type `named` and the role `Author`.
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
 
     + Attributes (BulkCreateUser)
     


### PR DESCRIPTION
When generating Python code for example from requests the header `X-Acrolinx-Auth` is also there with a placeholder value `your_access_token`, indicating the API user to replace with the actual API token.

**Adds:**
- Add missing `+ Headers` section with `X-Acrolinx-Auth: your_access_token` to the following sections:
  - User API
  - Role API
  - Checking API
    -  Add both `X-Acrolinx-Auth: your_access_token` and `X-Acrolinx-Client: your_client_signature` (Fox checking API the client signature also required)
    
**Example:**
![image](https://user-images.githubusercontent.com/8113120/130091469-37504d05-826c-4547-b4a2-cc4d35d1909d.png)

**Fixes:**
- Some URI parameters not showing up (for Group Role API, some checking API, ..)
  - Also URI parameter description should be added after `-` (replaced `...`)
  - URI parameters should be under sections, not `+ Request` (See Parent sections: https://apiblueprint.org/documentation/specification.html#uri-parameters-section )
Screenshots: 
![image](https://user-images.githubusercontent.com/8113120/130092420-4dc73083-25ca-4294-84a5-3279afd8eed7.png)
 
