### PR TITLE
DEV-26982 Remove empty privileges array from User response

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1435,13 +1435,11 @@ The example response includes the pagination URLs in the `links` object so you k
                         "roles": [
                             {
                                 "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                                "name": "Term Contributor",
-                                "privileges": []
+                                "name": "Term Contributor"
                             },
                             {
                                 "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                                "name": "Term Browser Administrator",
-                                "privileges": []
+                                "name": "Term Browser Administrator"
                             }
                         ],
                         "customFields": [
@@ -1474,8 +1472,7 @@ The example response includes the pagination URLs in the `links` object so you k
                         "roles": [
                             {
                                 "id": "898a7c32-2c39-4cde-becb-16f22243e9b8",
-                                "name": "Analytics Read-Only User",
-                                "privileges": []
+                                "name": "Analytics Read-Only User"
                             }
                         ],
                         "customFields": [
@@ -1617,13 +1614,11 @@ You’ll also see properties, roles, and custom fields.
                     "roles": [
                         {
                             "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                            "name": "Term Contributor",
-                            "privileges": []
+                            "name": "Term Contributor"
                         },
                         {
                             "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                            "name": "Term Browser Administrator",
-                            "privileges": []
+                            "name": "Term Browser Administrator"
                         }
                     ],
                     "customFields": [
@@ -1718,13 +1713,11 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                            "name": "Term Contributor",
-                            "privileges": []
+                            "name": "Term Contributor"
                         },
                         {
                             "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                            "name": "Term Browser Administrator",
-                            "privileges": []
+                            "name": "Term Browser Administrator"
                         }
                     ],
                     "customFields": [
@@ -1833,8 +1826,7 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "8c66c4e2-174a-4f77-b8d4-71bfa9ca4d2e",
-                            "name": "Author",
-                            "privileges": []
+                            "name": "Author"
                         }
                     ],
                     "customFields": [
@@ -2014,8 +2006,7 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "8c66c4e2-174a-4f77-b8d4-71bfa9ca4d2e",
-                            "name": "Author",
-                            "privileges": []
+                            "name": "Author"
                         }
                     ],
                     "customFields": [
@@ -2197,13 +2188,11 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                            "name": "Term Contributor",
-                            "privileges": []
+                            "name": "Term Contributor"
                         },
                         {
                             "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                            "name": "Term Browser Administrator",
-                            "privileges": []
+                            "name": "Term Browser Administrator"
                         }
                     ],
                     "customFields": [
@@ -2381,13 +2370,11 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                            "name": "Term Contributor",
-                            "privileges": []
+                            "name": "Term Contributor"
                         },
                         {
                             "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                            "name": "Term Browser Administrator",
-                            "privileges": []
+                            "name": "Term Browser Administrator"
                         }
                     ],
                     "customFields": [
@@ -2623,13 +2610,11 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                            "name": "Term Contributor",
-                            "privileges": []
+                            "name": "Term Contributor"
                         },
                         {
                             "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                            "name": "Term Browser Administrator",
-                            "privileges": []
+                            "name": "Term Browser Administrator"
                         }
                     ],
                     "customFields": [
@@ -2730,13 +2715,11 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                            "name": "Term Contributor",
-                            "privileges": []
+                            "name": "Term Contributor"
                         },
                         {
                             "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                            "name": "Term Browser Administrator",
-                            "privileges": []
+                            "name": "Term Browser Administrator"
                         }
                     ],
                     "customFields": [
@@ -2866,13 +2849,11 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                            "name": "Term Contributor",
-                            "privileges": []
+                            "name": "Term Contributor"
                         },
                         {
                             "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                            "name": "Term Browser Administrator",
-                            "privileges": []
+                            "name": "Term Browser Administrator"
                         }
                     ],
                     "customFields": [
@@ -2951,13 +2932,11 @@ This is an alternative way of getting information about the current (in request 
                     "roles": [
                         {
                             "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
-                            "name": "Term Contributor",
-                            "privileges": []
+                            "name": "Term Contributor"
                         },
                         {
                             "id": "6a0ebe93-f735-4b08-b6f2-66f7ecc70190",
-                            "name": "Term Browser Administrator",
-                            "privileges": []
+                            "name": "Term Browser Administrator"
                         }
                     ],
                     "customFields": [


### PR DESCRIPTION
The User API returns the user data including the associated roles. However,  Roles can contain multiple privileges and are used to assign a set of privileges to users but in the User API when the client requests information about the user this transitive relation is not being populated. Instead only the associated roles are returned for each user in the response. 

Now we have removed this quite confusing empty privileges array from the User response model under the `/api/v1/users` route. 

```
// GetAllUsers - Before
{
    "links": {},
    "data": [
        {
            "id": "6b0cafac-04db-4e43-9ea8-dcd2b756574d",
            "username": "termcontribution",
            "fullName": "",
            "createdOn": "2021-02-23T08:38:47.500Z",
            "activeTokenId": "",
            "lastIntegrationAccess": "1970-01-01T00:00:00Z",
            "licenseType": "builtin",
            "licenseStatus": "inactive",
            "checkingFrequency": "infrequent",
            "roles": [
                {
                    "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
                    "name": "Term Contributor",
                    "privileges": [], // <-- Note the empty array here
                    "default": false
                },
                ...
            ],
            "customFields": [
                {
                    "key": "Department",
                    "displayName": "Department",
                    "inputType": "optional",
                    "type": "list",
                    "possibleValues": [
                        "Example Department"
                    ]
                }
            ]
        },
        ...
        ]
}

// GetAllUsers - After
{
    "links": {},
    "data": [
        {
            "id": "6b0cafac-04db-4e43-9ea8-dcd2b756574d",
            "username": "termcontribution",
            "fullName": "",
            "createdOn": "2021-02-23T08:38:47.500Z",
            "activeTokenId": "",
            "lastIntegrationAccess": "1970-01-01T00:00:00Z",
            "licenseType": "builtin",
            "licenseStatus": "inactive",
            "checkingFrequency": "infrequent",
            "roles": [
                {
                    "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
                    "name": "Term Contributor",
                    "default": false
                    // <-------- Note that, there is no `privielges` node here 
                },
               ...
            ],
            "customFields": [
                {
                    "key": "Department",
                    "displayName": "Department",
                    "inputType": "optional",
                    "type": "list",
                    "possibleValues": [
                        "Example Department"
                    ]
                }
            ]
        },
        ...
        ]
}
```