### PR TITLE
DEV-27658: add functionality to sort by user custom fields

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1546,6 +1546,30 @@ The example response includes the pagination URLs in the `links` object so you k
             }
         }
 
+        // when key the sort by customFields.key is not specified
+        {
+          "links": {},
+          "error": {
+            "reference": "f744d41f-7eb6-4df6-81cb-7ddb43eb8900",
+            "detail": "customFields cannot be null or empty.",
+            "type": "client",
+            "title": "Bad Request",
+            "status": 400
+          }
+        }
+
+        // when key the sort by customFields.key is not in customFields list for example customFields.Department
+        {
+          "links": {},
+          "error": {
+            "reference": "f744d41f-7eb6-4df6-81cb-7ddb43eb8900",
+            "detail": "Department is not a valid user custom sortable field",
+            "type": "client",
+            "title": "Bad Request",
+            "status": 400
+          }
+        }
+
 + Response 401 (application/json)
 
         // when the access token in the request is missing or invalid


### PR DESCRIPTION
Allows the API `{{server_root}}/api/v1/user?sort=customFields.{key}` response to be sorted using specified custom field key paramater.

The `{key}` value is from `key` value from `customFields `

**NOTE**
Request to sort a custom field must have `customFields` followed by `.` then the `{key}` value -> `customFields.{key}` to identify it as a request to sort by the specified custom field key

**EXAMPLE:**
From the sample response below, `{key}` value is `Department` -> `{{server_root}}/api/v1/user?sort=customFields.Department`
```
// GetAllUsers API response
{
    "links": {},
    "data": [
        {
            "id": "6b0cafac-04db-4e43-9ea8-dcd2b756574d",
            "username": "termcontribution",
            "fullName": "",
            "createdOn": "2021-02-23T08:38:47.500Z",
            "activeTokenId": "",
            "lastIntegrationAccess": "1970-01-01T00:00:00Z",
            "licenseType": "builtin",
            "licenseStatus": "inactive",
            "checkingFrequency": "infrequent",
            "roles": [
                {
                    "id": "d66d4d00-3381-11e0-bc8e-0800200c9a66",
                    "name": "Term Contributor",
                    "privileges": [], // <-- Note the empty array here
                    "default": false
                },
                ...
            ],
            "customFields": [
                {
                    "key": "Department",
                    "displayName": "Department",
                    "inputType": "optional",
                    "type": "list",
                    "possibleValues": [
                        "Example Department"
                    ]
                }
            ]
        },
        ...
        ]
}
```

**SUCCESS RESPONSE**
A successful request with correct `customFields.{key}` will returns `HTTP STATUS 200: OK` with sorted result based on specified key parameter. 

**ERROR RESPONSE**
Invalid custom field key parameter `customFields.{key}` will return `HTTP STATUS 400: BAD REQUEST` 

Examples of invalid requests:

+ No key value specified -> `{{server_root}}/api/v1/user?sort=customFields.`
+ Key value `xxx` not in customFields list -> `{{server_root}}/api/v1/user?sort=customFields.xxx`
+ Custom field sort value not having `.` to identify the key -> `{{server_root}}/api/v1/user?sort=customFieldsxxx`

```
// Sample error response with detail showing error message
{
  "links": {},
  "error": {
    "reference": "f744d41f-7eb6-4df6-81cb-7ddb43eb8900",
    "detail": "customFields cannot be null or empty.",
    "type": "client",
    "title": "Bad Request",
    "status": 400
  }
}
```