### PR TITLE
DEV-27658: add functionality to sort by user custom fields

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1551,26 +1551,26 @@ The example response includes the pagination URLs in the `links` object so you k
 
         // when the custom field name cannot be found
         {
-          "links": {},
-          "error": {
-            "reference": "1095ac3c-4418-467d-930e-d517b8e34beb",
-            "detail": "Telephone is not a valid user custom sortable field",
-            "type": "client",
-            "title": "Bad Request",
-            "status": 400
-          }
+            "links": {},
+            "error": {
+                "reference": "1095ac3c-4418-467d-930e-d517b8e34beb",
+                "detail": "Telephone is not a valid user custom sortable field",
+                "type": "client",
+                "title": "Bad Request",
+                "status": 400
+            }
         }
 
         // when the custom field name is null or empty
         {
-          "links": {},
-          "error": {
-            "reference": "1095ac3c-4418-467d-930e-d517b8e34beb",
-            "detail": "customFields cannot be null or empty.",
-            "type": "client",
-            "title": "Bad Request",
-            "status": 400
-          }
+            "links": {},
+            "error": {
+                "reference": "1095ac3c-4418-467d-930e-d517b8e34beb",
+                "detail": "customFields cannot be null or empty.",
+                "type": "client",
+                "title": "Bad Request",
+                "status": 400
+            }
         }
 
 + Response 401 (application/json)


### PR DESCRIPTION
Allows the API `{{server_root}}/api/v1/user?sort=customFields.{key}` response to be sorted using specified custom field key paramater.

The `{key}` value is from `key` value from `customFields `

**NOTE**
Request to sort a custom field must have `customFields` followed by `.` then the `{key}` value -> `customFields.{key}` to identify it as a request to sort by the specified custom field key