### PR TITLE
DEV-27658: add functionality to sort by user custom fields

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1521,7 +1521,7 @@ The example response includes the pagination URLs in the `links` object so you k
                     {
                         "title": "Validation error",
                         "constraint": "Pattern",
-                        "detail": "must match \"[+-]?[A-Za-z0-9_.]{1,50}\"",
+                        "detail": "must match \"[+-]?.+\"",
                         "invalidValue": "+"
                     }
                 ],


### PR DESCRIPTION
Allows the API `{{server_root}}/api/v1/user?sort=customFields.{key}` response to be sorted using specified custom field key paramater.

The `{key}` value is from `key` value from `customFields `

**NOTE**
+ Request to sort a custom field must have `customFields` followed by `.` then the `{key}` value -> `customFields.{key}` to identify it as a request to sort by the specified custom field key
+ The only check will be for `+` or `-` for ascending or descending sort and the sort parameter value will accept all characters(including special characters and spaces)