### PR TITLE
DEV-27630 Document User API endpoint(s) for request user(s) to update custom field value

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3825,7 +3825,7 @@ noted in the Create User API section.
 
 ### Request User Information Update in Bulk  [PUT /api/v1/user/bulk/_request_cf_update]
 
-This API is the bulk variant of the same "Request actualize Custom field values" from the User Commands group.
+This API is the bulk operation for "Request User Information Update" from the "User Commands" group.
 It lets you ask multiple users to update their user information. 
 
 **Note:** There are currently no limitations on the number of users a client can ask for an information update.

--- a/apiary.apib
+++ b/apiary.apib
@@ -3403,17 +3403,17 @@ This method uses the *id* to release an active license consumed by a user.
 
 ### Request actualize Custom field values  [PUT /api/v1/user/{id}/_request_cf_update]
 
-The user specified by the *id* in this request will be notified to actualize his custom field values. 
+The user specified by the *id* in this request will be notified to actualize their custom field values. 
 
 **Note:**
 - When the user signs-in the next time the system will force them to re-enter the custom field values via a form.
-- If you repeat the request with a user id who had been request earlier, you won't see an error. 
+- If you repeat the request with the same user UUID, you won't see an error. 
 - To do this, you need the `UserAndRoles.editUser` privilege.
 
 + Parameters
     + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
 
-+ Request Request one User to actualize his custom field values
++ Request Request one User to actualize their custom field values
 
     + Headers
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3401,7 +3401,7 @@ This method uses the *id* to release an active license consumed by a user.
             }
         }
 
-### Request actualize Custom field values  [PUT /api/v1/user/{id}/_request_cf_update]
+### Request User Information Update  [PUT /api/v1/user/{id}/_request_cf_update]
 
 The user specified by the *id* in this request will be notified to actualize their custom field values. 
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3407,7 +3407,7 @@ The user specified by the *id* in this request will be notified to actualize his
 
 **Note:**
 - When the user signs-in the next time the system will force him to re-enter the custom field values via a form.
-- If you repeat the request with an user id who had been request earlier, you wont see an error. 
+- If you repeat the request with a user id who had been request earlier, you won't see an error. 
 - To do this, you need the `UserAndRoles.editUser` privilege.
 
 + Parameters

--- a/apiary.apib
+++ b/apiary.apib
@@ -3823,7 +3823,7 @@ noted in the Create User API section.
         }
 
 
-### Request actualize Custom field values in Bulk  [PUT /api/v1/user/bulk/_request_cf_update]
+### Request Bulk User Information Update  [PUT /api/v1/user/bulk/_request_cf_update]
 
 This API is the bulk variant of the same "Request actualize Custom field values" from the User Commands group.
 It lets you request multiple users to actialize their custom field values. 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3406,7 +3406,7 @@ This method uses the *id* to release an active license consumed by a user.
 The user specified by the *id* in this request will be notified to actualize his custom field values. 
 
 **Note:**
-- When the user signs-in the next time the system will force him to re-enter the custom field values via a form.
+- When the user signs-in the next time the system will force them to re-enter the custom field values via a form.
 - If you repeat the request with a user id who had been request earlier, you won't see an error. 
 - To do this, you need the `UserAndRoles.editUser` privilege.
 
@@ -3852,7 +3852,6 @@ It lets you request multiple users to actialize their custom field values.
 
     + Body
 
-            // All success
             {
                 "results": [
                     {
@@ -3869,6 +3868,82 @@ It lets you request multiple users to actialize their custom field values.
                     }
                 ],
                 "errors": []
+            }
+
++ Response 403 (application/json)
+
+        // when you don’t have the neccessary privileges ("UserAndRoles.editUser")
+        {
+        "links": {},
+            "error": {
+                "detail": "The user does not have the required privileges to perform the operation.",
+                "type": "insufficientPrivileges",
+                "title": "Insufficient privileges",
+                "status": 403
+            }
+        }
+
++ Response 500 (application/json)
+
+        // when there’s an unspecified error
+        {
+            "links": {},
+            "error": {
+                "reference": "2f17395a-770f-439e-b2b4-65c6c03717db",
+                "detail": "An unspecific server error occurred. Details may be found in the Acrolinx log files.",
+                "type": "server",
+                "title": "Unspecific server error",
+                "status": 500
+            }
+        }
+
++ Request Example with invalid or unknown user ids in request (application/json)
+
+  + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
+    + Attributes (object)
+    
+    + Body
+
+            [
+                "f265a1b7-4fed-4ff3-b2d4-9dc6e29e268f",
+                "no-user-with-this-id-for-sure",
+                null
+            ]
+    
++ Response 207 (application/json)
+
+    + Attributes (BulkResultResponse)
+
+    + Body
+
+           {
+                "results": [
+                    {
+                        "status": 204,
+                        "id": "f265a1b7-4fed-4ff3-b2d4-9dc6e29e268f"
+                    }
+                ],
+                "errors": [
+                    {
+                        "status": 400,
+                        "id": null,
+                        "type": "client",
+                        "title": "Bad Request",
+                        "detail": "The provided uuid is not a valid user id.",
+                        "reference": "d18c9c62-faed-4753-b4f4-6a6d6e967d9e"
+                    },
+                    {
+                        "status": 404,
+                        "id": "no-user-with-this-id-for-sure",
+                        "type": "client",
+                        "title": "Not Found",
+                        "detail": "User does not exist with the given id.",
+                        "reference": "592577df-4526-4eea-a4bb-1628102a063c"
+                    }
+                ]
             }
 
 + Response 403 (application/json)

--- a/apiary.apib
+++ b/apiary.apib
@@ -3823,7 +3823,7 @@ noted in the Create User API section.
         }
 
 
-### Request Bulk User Information Update  [PUT /api/v1/user/bulk/_request_cf_update]
+### Request User Information Update in Bulk  [PUT /api/v1/user/bulk/_request_cf_update]
 
 This API is the bulk variant of the same "Request actualize Custom field values" from the User Commands group.
 It lets you ask multiple users to update their user information. 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3828,7 +3828,7 @@ noted in the Create User API section.
 This API is the bulk variant of the same "Request actualize Custom field values" from the User Commands group.
 It lets you ask multiple users to update their user information. 
 
-**Note:** Currently there is no limitations in terms of the maximal users a client could request for update.
+**Note:** There are currently no limitations on the number of users a client can ask for an information update.
 
 + Request Request multiple Users to actualize their Custom field values (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3897,7 +3897,7 @@ It lets you ask multiple users to update their user information.
             }
         }
 
-+ Request Example with invalid or unknown user ids in request (application/json)
++ Request Error Example - If user ids in the request are invalid or unknown (application/json)
 
   + Headers
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3826,7 +3826,7 @@ noted in the Create User API section.
 ### Request Bulk User Information Update  [PUT /api/v1/user/bulk/_request_cf_update]
 
 This API is the bulk variant of the same "Request actualize Custom field values" from the User Commands group.
-It lets you request multiple users to actialize their custom field values. 
+It lets you ask multiple users to update their user information. 
 
 **Note:** Currently there is no limitations in terms of the maximal users a client could request for update.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3860,11 +3860,11 @@ It lets you request multiple users to actialize their custom field values.
                         "id": "1f17395a-770f-439e-b2b4-65c6c03717db",
                     },
                     {
-                        "status": 201,
+                        "status": 204,
                         "id": "2f17395a-770f-439e-b2b4-65c6c03717db",
                     },
                     {
-                        "status": 201,
+                        "status": 204,
                         "id": "3f17395a-770f-439e-b2b4-65c6c03717db",
                     }
                 ],

--- a/apiary.apib
+++ b/apiary.apib
@@ -3413,7 +3413,7 @@ The user specified by the *id* in this request will be asked to update their use
 + Parameters
     + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
 
-+ Request Request one User to actualize their custom field values
++ Request Ask one user to update their user information
 
     + Headers
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3404,7 +3404,11 @@ This method uses the *id* to release an active license consumed by a user.
 ### Request actualize Custom field values  [PUT /api/v1/user/{id}/_request_cf_update]
 
 The user specified by the *id* in this request will be notified to actualize his custom field values. 
-When the user signs-in the next time the system will force him to re-enter the custom field values via a form.
+
+**Note:**
+- When the user signs-in the next time the system will force him to re-enter the custom field values via a form.
+- If you repeat the request with an user id who had been request earlier, you wont see an error. 
+- To do this, you need the `UserAndRoles.editUser` privilege.
 
 + Parameters
     + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier

--- a/apiary.apib
+++ b/apiary.apib
@@ -3919,32 +3919,32 @@ It lets you request multiple users to actialize their custom field values.
 
     + Body
 
-           {
-                "results": [
-                    {
-                        "status": 204,
-                        "id": "f265a1b7-4fed-4ff3-b2d4-9dc6e29e268f"
-                    }
-                ],
-                "errors": [
-                    {
-                        "status": 400,
-                        "id": null,
-                        "type": "client",
-                        "title": "Bad Request",
-                        "detail": "The provided uuid is not a valid user id.",
-                        "reference": "d18c9c62-faed-4753-b4f4-6a6d6e967d9e"
-                    },
-                    {
-                        "status": 404,
-                        "id": "no-user-with-this-id-for-sure",
-                        "type": "client",
-                        "title": "Not Found",
-                        "detail": "User does not exist with the given id.",
-                        "reference": "592577df-4526-4eea-a4bb-1628102a063c"
-                    }
-                ]
-            }
+            {
+                 "results": [
+                     {
+                         "status": 204,
+                         "id": "f265a1b7-4fed-4ff3-b2d4-9dc6e29e268f"
+                     }
+                 ],
+                 "errors": [
+                     {
+                         "status": 400,
+                         "id": null,
+                         "type": "client",
+                         "title": "Bad Request",
+                         "detail": "The provided uuid is not a valid user id.",
+                         "reference": "d18c9c62-faed-4753-b4f4-6a6d6e967d9e"
+                     },
+                     {
+                         "status": 404,
+                         "id": "no-user-with-this-id-for-sure",
+                         "type": "client",
+                         "title": "Not Found",
+                         "detail": "User does not exist with the given id.",
+                         "reference": "592577df-4526-4eea-a4bb-1628102a063c"
+                     }
+                 ]
+             }
 
 + Response 403 (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3403,7 +3403,7 @@ This method uses the *id* to release an active license consumed by a user.
 
 ### Request User Information Update  [PUT /api/v1/user/{id}/_request_cf_update]
 
-The user specified by the *id* in this request will be notified to actualize their custom field values. 
+The user specified by the *id* in this request will be asked to update their user information. 
 
 **Note:**
 - When the user signs-in the next time the system will force them to re-enter the custom field values via a form.

--- a/apiary.apib
+++ b/apiary.apib
@@ -3830,7 +3830,7 @@ It lets you ask multiple users to update their user information.
 
 **Note:** There are currently no limitations on the number of users a client can ask for an information update.
 
-+ Request Request multiple Users to actualize their Custom field values (application/json)
++ Request Ask multiple users to update their user information (application/json)
 
   + Headers
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3401,6 +3401,63 @@ This method uses the *id* to release an active license consumed by a user.
             }
         }
 
+### Request actualize Custom field values  [PUT /api/v1/user/{id}/_request_cf_update]
+
+The user specified by the *id* in this request will be notified to actualize his custom field values. 
+When the user signs-in the next time the system will force him to re-enter the custom field values via a form.
+
++ Parameters
+    + id: `eb323701-839f-4998-b56e-3e20c70259c5` (required, string) - UUID of the user, unique identifier
+
++ Request Request one User to actualize his custom field values
+
+    + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
++ Response 204
+
++ Response 401 (application/json)
+
+        // when the access token in the request is missing or invalid
+        {
+            "links": {},
+            "error": {
+                "detail": "Valid authentication has either not been provided or is insufficient.",
+                "type": "auth",
+                "title": "Invalid authentication",
+                "status": 401
+            }
+        }
+
++ Response 403 (application/json)
+
+        // when you don’t have the neccessary privileges ("UserAndRoles.editUser")
+        {
+            "links": {},
+            "error": {
+                "reference": "64311fe7-2a7e-4e3b-849e-4e9ff8651400",
+                "detail": "The user does not have the required privileges to perform the operation.",
+                "type": "insufficientPrivileges",
+                "title": "Insufficient privileges",
+                "status": 403
+            }
+        }
+
++ Response 404 (application/json)
+
+        // when the user wasn’t found in the database by its *id*
+        {
+        "links": {},
+            "error": {
+                "reference": "e49d3cd5-330a-408d-84a1-e9ecf20677bf",
+                "detail": "An unspecific client error occurred.",
+                "type": "client",
+                "title": "Not Found",
+                "status": 404
+            }
+        }
+
 ### Export a List of Users [GET /api/v1/user/_export]
 
 This API provides an easy way to export a concise user list in various file formats.

--- a/apiary.apib
+++ b/apiary.apib
@@ -3406,7 +3406,7 @@ This method uses the *id* to release an active license consumed by a user.
 The user specified by the *id* in this request will be asked to update their user information. 
 
 **Note:**
-- When the user signs-in the next time the system will force them to re-enter the custom field values via a form.
+- The next time the user signs in, they'll need to re-enter their user information via a form.
 - If you repeat the request with the same user UUID, you won't see an error. 
 - To do this, you need the `UserAndRoles.editUser` privilege.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3822,6 +3822,82 @@ noted in the Create User API section.
             }
         }
 
+
+### Request actualize Custom field values in Bulk  [PUT /api/v1/user/bulk/_request_cf_update]
+
+This API is the bulk variant of the same "Request actualize Custom field values" from the User Commands group.
+It lets you request multiple users to actialize their custom field values. 
+
+**Note:** Currently there is no limitations in terms of the maximal users a client could request for update.
+
++ Request Request multiple Users to actualize their Custom field values (application/json)
+
+  + Headers
+
+            X-Acrolinx-Auth: your_access_token
+
+    + Attributes (object)
+    
+    + Body
+
+            [
+                "1f17395a-770f-439e-b2b4-65c6c03717db",
+                "2f17395a-770f-439e-b2b4-65c6c03717db",
+                "3f17395a-770f-439e-b2b4-65c6c03717db",
+            ]
+    
++ Response 207 (application/json)
+
+    + Attributes (BulkResultResponse)
+
+    + Body
+
+            // All success
+            {
+                "results": [
+                    {
+                        "status": 204,
+                        "id": "1f17395a-770f-439e-b2b4-65c6c03717db",
+                    },
+                    {
+                        "status": 201,
+                        "id": "2f17395a-770f-439e-b2b4-65c6c03717db",
+                    },
+                    {
+                        "status": 201,
+                        "id": "3f17395a-770f-439e-b2b4-65c6c03717db",
+                    }
+                ],
+                "errors": []
+            }
+
++ Response 403 (application/json)
+
+        // when you don’t have the neccessary privileges ("UserAndRoles.editUser")
+        {
+        "links": {},
+            "error": {
+                "detail": "The user does not have the required privileges to perform the operation.",
+                "type": "insufficientPrivileges",
+                "title": "Insufficient privileges",
+                "status": 403
+            }
+        }
+
++ Response 500 (application/json)
+
+        // when there’s an unspecified error
+        {
+            "links": {},
+            "error": {
+                "reference": "2f17395a-770f-439e-b2b4-65c6c03717db",
+                "detail": "An unspecific server error occurred. Details may be found in the Acrolinx log files.",
+                "type": "server",
+                "title": "Unspecific server error",
+                "status": 500
+            }
+        }
+
 # Group Licenses API
 
 License information is provided by the following set of APIs.


### PR DESCRIPTION
Add a call to the User API which allows requesting an update for users' custom fields. 

Note: This call requires the `UserAndRoles.editUser` privilege from the client.

+ Documented under the `User Commands` group
   + Added section for request `Request actualize Custom field values (for single user)`
      + Example request and response
+ Documented under the `User Bulk Opreations` group
    + Added section for request `Request actualize Custom field values in Bulk (for multiple users)`
       + Example request and response