### PR TITLE
term API doc: added referenced ACTIF sample file

### DIFF
--- a/doc/example-entry.actif.xml
+++ b/doc/example-entry.actif.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<actif xmlns="http://www.acrolinx.com" version="1.0">
+    <origin date="2014-01-28T18:44:07.491+01:00">
+        <tool/>
+    </origin>
+    <data>
+        <source-languages>
+            <lang>en</lang>
+        </source-languages>
+        <entry>
+            <value field="entry/id">13</value>
+            <value field="entry/uuid">a918fccf-4a94-4398-b260-4d792289952c</value>
+            <head>
+                <term>
+                    <name>return air</name>
+                    <language>en</language>
+                    <value field="term/status">proposed</value>
+                    <value field="term/domain">undefined domain</value>
+                    <value field="term/uuid">120bdf01-4818-4a2c-bcea-4f875b6b129a</value>
+                    <value field="term/id">1371197695606</value>
+                    <value field="term/frequency">0</value>
+                    <value field="term/creation-date-time">2011-06-28T11:55:28+02:00</value>
+                    <value field="term/creator-user-name">admin</value>
+                    <value field="term/last-modification-date-time">2011-06-28T12:01:57+02:00</value>
+                    <value field="term/last-modifier">admin</value>
+                    <value field="Core">undefined</value>
+                    <value field="partOfSpeech">undefined</value>
+                    <value field="gender">undefined</value>
+                    <value field="processStatus">unprocessed</value>
+                    <value field="termType">undefined</value>
+                    <complex-value field="term/msr">
+                        <attribute name="analysisMode">string</attribute>
+                    </complex-value>
+                </term>
+            </head>
+            <term>
+                <name>Abluftmenge</name>
+                <language>de</language>
+                <value field="term/status">proposed</value>
+                <value field="term/domain">undefined domain</value>
+                <value field="term/uuid">44641d47-ddf3-4bb4-b1d4-a22a3fb42f64</value>
+                <value field="term/id">1371197695646</value>
+                <value field="term/frequency">0</value>
+                <value field="term/creation-date-time">2011-06-28T11:55:28+02:00</value>
+                <value field="term/creator-user-name">admin</value>
+                <value field="term/last-modification-date-time">2011-06-30T10:50:48+02:00</value>
+                <value field="term/last-modifier">admin</value>
+                <value field="Core">undefined</value>
+                <value field="partOfSpeech">undefined</value>
+                <value field="gender">undefined</value>
+                <value field="processStatus">unprocessed</value>
+                <value field="termType">undefined</value>
+                <complex-value field="term/msr">
+                    <attribute name="analysisMode">string</attribute>
+                </complex-value>
+            </term>
+            <term>
+                <name>débit d'air repris</name>
+                <language>fr</language>
+                <value field="term/status">proposed</value>
+                <value field="term/domain">undefined domain</value>
+                <value field="term/uuid">5334a674-848b-44a3-8b42-1756d38717ef</value>
+                <value field="term/id">1371197695614</value>
+                <value field="term/frequency">0</value>
+                <value field="term/creation-date-time">2011-06-28T11:55:28+02:00</value>
+                <value field="term/creator-user-name">admin</value>
+                <value field="term/last-modification-date-time">2011-06-28T12:01:39+02:00</value>
+                <value field="term/last-modifier">admin</value>
+                <value field="Core">undefined</value>
+                <value field="partOfSpeech">undefined</value>
+                <value field="gender">undefined</value>
+                <value field="processStatus">unprocessed</value>
+                <value field="termType">undefined</value>
+                <complex-value field="term/msr">
+                    <attribute name="analysisMode">string</attribute>
+                </complex-value>
+            </term>
+            <term>
+                <name>débit d'évacuation</name>
+                <language>fr</language>
+                <value field="term/status">proposed</value>
+                <value field="term/domain">undefined domain</value>
+                <value field="term/uuid">38e4ce12-4175-465e-a26f-4bb6d8a7ea15</value>
+                <value field="term/id">1371197695654</value>
+                <value field="term/frequency">0</value>
+                <value field="term/creation-date-time">2011-06-28T11:55:28+02:00</value>
+                <value field="term/creator-user-name">admin</value>
+                <value field="term/last-modification-date-time">2011-06-28T12:01:54+02:00</value>
+                <value field="term/last-modifier">admin</value>
+                <value field="Core">undefined</value>
+                <value field="partOfSpeech">undefined</value>
+                <value field="gender">undefined</value>
+                <value field="processStatus">unprocessed</value>
+                <value field="termType">undefined</value>
+                <complex-value field="term/msr">
+                    <attribute name="analysisMode">string</attribute>
+                </complex-value>
+            </term>
+        </entry>
+    </data>
+</actif>

--- a/term-api.md
+++ b/term-api.md
@@ -561,7 +561,7 @@ Return codes:
   URL of the inserted/updated entry.
 - If no new entry was created or updated but it’s no error (for example, the input data could be empty and not contain any
   insertable entry), the return code is 204 (No Content).
-- If the input data contains more than one entry (which is allowed), all will be created or updated respectively, but
+- If the input data contains more than one entry (which is allowed), all entries in the input data will be created or updated respectively, but
   the Location header will only contain the URL of one of them.
 
 Example (sending [example-entry.actif.xml](doc/example-entry.actif.xml)):

--- a/term-api.md
+++ b/term-api.md
@@ -564,10 +564,10 @@ Return codes:
 - If the input data contains more than one entry (which is allowed), all will be created or updated respectively, but
   the Location header will only contain the URL of one of them.
 
-Example (sending [example-entry.actif.xml](./example-entry.actif.xml)):
+Example (sending [example-entry.actif.xml](doc/example-entry.actif.xml)):
 
 ```bash
-curl -i -H "Accept: application/json" -H "Content-Type: application/vnd.acrolinx.actif+xml" -H "Authorization: session ee7ac269aed25b4e" -X POST http://${serverHostName}:8031/iq/services/v7/rest/terminology/entries -d "`cat example-entry.actif.xml`"
+curl -i -H "Accept: application/json" -H "Content-Type: application/vnd.acrolinx.actif+xml" -H "Authorization: session ee7ac269aed25b4e" -X POST http://${serverHostName}:8031/iq/services/v7/rest/terminology/entries -d "`cat doc/example-entry.actif.xml`"
 ```
 
 ```text

--- a/term-api.md
+++ b/term-api.md
@@ -557,10 +557,10 @@ Required privileges:
 
 Return codes:
 
-- In both cases, creation or update, the return code of the service is 201 (Created) and the Location header gets the
+- For both creation and update, the return code is 201 (created) and the "Location" header gets the
   URL of the inserted/updated entry.
-- If the input data does not contain entry to create or update, the return code is 204 (No Content).
-- If the input data contains more than one entry (which is allowed), all entries in the input data will be created or updated respectively, but
+- If the input data doesn't contain an entry that needs to be created or updated, you'll see a 204 (no content).
+- If the input data contains more than one entry (which is allowed), all entries in the input data will be created or updated respectively. However,
   the "Location" header will only contain the URL of one of them.
 
 Example (sending [example-entry.actif.xml](doc/example-entry.actif.xml)):

--- a/term-api.md
+++ b/term-api.md
@@ -559,10 +559,9 @@ Return codes:
 
 - In both cases, creation or update, the return code of the service is 201 (Created) and the Location header gets the
   URL of the inserted/updated entry.
-- If no new entry was created or updated but it’s no error (for example, the input data could be empty and not contain any
-  insertable entry), the return code is 204 (No Content).
+- If the input data does not contain entry to create or update, the return code is 204 (No Content).
 - If the input data contains more than one entry (which is allowed), all entries in the input data will be created or updated respectively, but
-  the Location header will only contain the URL of one of them.
+  the "Location" header will only contain the URL of one of them.
 
 Example (sending [example-entry.actif.xml](doc/example-entry.actif.xml)):
 


### PR DESCRIPTION
* Terminology API documentation is referencing a sample ACTIF term file in the "create term entries" section
* this ACTIF file is now added (to the `doc/` subfolder) 