### PR TITLE
DEV-27658: allowed special characters in custom field keys

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1333,6 +1333,7 @@ You can add a `+` or `-` to display the list in ascending or descending order re
 - By default, the list appears in ascending order.
 - Query parameter `licenseType` sorts by two fields: `licenseType` and `licenseStatus`.
 - To sort by custom field, sort value must have `customFields` followed by `.` then the `{key}`, which is the name of the custom field
+- The following special characters are allowed in the custom field `{key}`: `` !@$^*()_+-=,./;'[]<>?:|~` ``
 
 So that the `+` character encoded to `%2B` stays valid, make sure that the query parameters are encoded in accordance
 with [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent). 

--- a/apiary.apib
+++ b/apiary.apib
@@ -1333,7 +1333,9 @@ You can add a `+` or `-` to display the list in ascending or descending order re
 - By default, the list appears in ascending order.
 - Query parameter `licenseType` sorts by two fields: `licenseType` and `licenseStatus`.
 - To sort by custom field, sort value must have `customFields` followed by `.` then the `{key}`, which is the name of the custom field
-- The following special characters are allowed in the custom field `{key}`: `` !@$^*()_+-=,./;'[]<>?:|~` ``
+
+So that the behavior of sorting custom fields is consistent, the following special characters can safely be sorted: `` !@$^*()_+-=,./;'[]<>?:|~` ``
+Other special characters may cause unexpected behavior when sorting.
 
 So that the `+` character encoded to `%2B` stays valid, make sure that the query parameters are encoded in accordance
 with [encodeURIComponent](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent). 


### PR DESCRIPTION
This adds a list of special characters that are allowed to be used when sorting custom fields. Note that this restrictions is only for sorting the custom fields. It does not put any restrictions on creating custom fields with other special characters not in the list.