### PR TITLE
DEV-27382 User Management API Minimum Version for Individual API Endpoints

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1324,7 +1324,7 @@ Security:
 
 **Note:** The table below shows the specific API request parameters by Core Platform version.
 
-| Request API                                                 | Core Platform Version |
+| API Request                                                 | Core Platform Version |
 |:------------------------------------------------------------|-----------------------|
 | `[GET /api/v1/user{?sort}]`                                 | `2021.06`             |
 | `[GET /api/v1/user{?page,per_page}]`                        | `2021.08`             |


### PR DESCRIPTION
The API docs need to have information on the minimum API version for which it is available 