### PR TITLE
docs: add section for health/status end point

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -6940,7 +6940,7 @@ access to the permission "Access to monitoring API" to use this API.
 
 This returns a successful response when the server can accept and process web requests.
 This does not tell you if the server is ready to process check requests. To get that information,
-making an API call to `api/v1/monitoring/health/status` will give that information.
+you can make an API call to `api/v1/monitoring/health/status`.
 
 The response of this api will contain a plain text message "OK" and a `200` response code. Access to the
 "Access to monitoring API" permission is not needed to use this API. An unsucesful response would

--- a/apiary.apib
+++ b/apiary.apib
@@ -6917,7 +6917,7 @@ A general summary of the health of the Acrolinx Platform.
 
 Returns a successful response when there is at least one language server available for checking.
 The response of this api will not contain a data body, just a `200` response code. Access to the
-"Access to monitoring API" permission is not needed to use this API.
+access to the permission "Access to monitoring API" to use this API.
 
 **Available since Core Platform version 2022.03**
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6944,7 +6944,7 @@ you can make an API call to `api/v1/monitoring/health/status`.
 
 This API response will contain the plain-text message "OK" and a `200` response code. You don't need
 access to the permission "Access to monitoring API" to use this API. If a response is unsuccessful,
-mean any other response that is not `200`.
+you'll see a response that isn't `200`.
 
 **Available since Core Platform version 2022.09**
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6912,6 +6912,30 @@ A general summary of the health of the Acrolinx Platform.
           }
         }
 
+## Get Health Metrics [GET /api/v1/monitoring/health/status]
+
+Returns 200 when there is at least one language server available for checking
+
+**Available since Core Platform version 2022.03**
+
++ Response 200
+
++ Response 503
+
+        {
+            "links": {},
+            "error": {
+                "reference": "abee2169-66ce-4566-b21a-f086d0c2c82a",
+                "detail": "Not all languages are available for checking.",
+                "type": "server",
+                "title": "Service Unavailable",
+                "status": 503
+            }
+        }
+
+
+
+
 # Data Structures
 
 ## Role (object) 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6943,7 +6943,7 @@ This does not tell you if the server is ready to process check requests. To get 
 you can make an API call to `api/v1/monitoring/health/status`.
 
 This API response will contain the plain-text message "OK" and a `200` response code. You don't need
-"Access to monitoring API" permission is not needed to use this API. An unsucesful response would
+access to the permission "Access to monitoring API" to use this API. If a response is unsuccessful,
 mean any other response that is not `200`.
 
 **Available since Core Platform version 2022.09**

--- a/apiary.apib
+++ b/apiary.apib
@@ -6935,6 +6935,22 @@ The respnse of his api will not contain a data body, just a 200 response code. A
             }
         }
 
+## Get Health Liveliness [GET /api/v1/monitoring/health/live]
+
+Returns a successful response when the server is accepting and processing web requests.
+This does not entail that the server is ready for processing check requests. However
+making an API call to `api/v1/monitoring/health/status` will give that information.
+
+The respnse of his api will contain a plain text message "OK" and a 200 response code. Access to the
+"Access to monitoring API" permission is not needed to use this API. An unsucesful response would
+mean any other response that is not `200`.
+
+**Available since Core Platform version 2022.09**
+
++ Response 200 (text/plain)
+
+        OK
+
 # Data Structures
 
 ## Role (object) 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6904,18 +6904,19 @@ A general summary of the health of the Acrolinx Platform.
 + Response 200 (application/json)
 
         {
-          "data": {
-            "languagesReady": {
-                "en": true,
-                "fr": true,
-                "ja": false
-          }
+            "data": {
+                "languagesReady": {
+                    "en": true,
+                    "fr": true,
+                    "ja": false
+                }
+            }
         }
 
 ## Get Health Status [GET /api/v1/monitoring/health/status]
 
 Returns a successful response when there is at least one language server available for checking.
-The response of this api will not contain a data body, just a 200 response code. Access to the
+The response of this api will not contain a data body, just a `200` response code. Access to the
 "Access to monitoring API" permission is not needed to use this API.
 
 **Available since Core Platform version 2022.03**
@@ -6941,7 +6942,7 @@ Returns a successful response when the server is accepting and processing web re
 This does not entail that the server is ready for processing check requests. However
 making an API call to `api/v1/monitoring/health/status` will give that information.
 
-The response of this api will contain a plain text message "OK" and a 200 response code. Access to the
+The response of this api will contain a plain text message "OK" and a `200` response code. Access to the
 "Access to monitoring API" permission is not needed to use this API. An unsucesful response would
 mean any other response that is not `200`.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6915,7 +6915,7 @@ A general summary of the health of the Acrolinx Platform.
 ## Get Health Status [GET /api/v1/monitoring/health/status]
 
 Returns a successful response when there is at least one language server available for checking.
-The respnse of his api will not contain a data body, just a 200 response code. Access to the
+The response of this api will not contain a data body, just a 200 response code. Access to the
 "Access to monitoring API" permission is not needed to use this API.
 
 **Available since Core Platform version 2022.03**
@@ -6941,7 +6941,7 @@ Returns a successful response when the server is accepting and processing web re
 This does not entail that the server is ready for processing check requests. However
 making an API call to `api/v1/monitoring/health/status` will give that information.
 
-The respnse of his api will contain a plain text message "OK" and a 200 response code. Access to the
+The response of this api will contain a plain text message "OK" and a 200 response code. Access to the
 "Access to monitoring API" permission is not needed to use this API. An unsucesful response would
 mean any other response that is not `200`.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6916,7 +6916,7 @@ A general summary of the health of the Acrolinx Platform.
 ## Get Health Status [GET /api/v1/monitoring/health/status]
 
 Returns a successful response when there is at least one language server available for checking.
-The response of this api will not contain a data body, just a `200` response code. Access to the
+This API response will only contain `200` response code. You don't need
 access to the permission "Access to monitoring API" to use this API.
 
 **Available since Core Platform version 2022.03**

--- a/apiary.apib
+++ b/apiary.apib
@@ -6942,7 +6942,7 @@ This returns a successful response when the server can accept and process web re
 This does not tell you if the server is ready to process check requests. To get that information,
 you can make an API call to `api/v1/monitoring/health/status`.
 
-The response of this api will contain a plain text message "OK" and a `200` response code. Access to the
+This API response will contain the plain-text message "OK" and a `200` response code. You don't need
 "Access to monitoring API" permission is not needed to use this API. An unsucesful response would
 mean any other response that is not `200`.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6939,7 +6939,7 @@ access to the permission "Access to monitoring API" to use this API.
 ## Get Health Liveliness [GET /api/v1/monitoring/health/live]
 
 This returns a successful response when the server can accept and process web requests.
-This does not entail that the server is ready for processing check requests. However
+This does not tell you if the server is ready to process check requests. To get that information,
 making an API call to `api/v1/monitoring/health/status` will give that information.
 
 The response of this api will contain a plain text message "OK" and a `200` response code. Access to the

--- a/apiary.apib
+++ b/apiary.apib
@@ -6915,7 +6915,7 @@ A general summary of the health of the Acrolinx Platform.
 
 ## Get Health Status [GET /api/v1/monitoring/health/status]
 
-Returns a successful response when there is at least one language server available for checking.
+This returns a successful response when at least one language server is available for checking.
 This API response will only contain `200` response code. You don't need
 access to the permission "Access to monitoring API" to use this API.
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6914,7 +6914,9 @@ A general summary of the health of the Acrolinx Platform.
 
 ## Get Health Metrics [GET /api/v1/monitoring/health/status]
 
-Returns 200 when there is at least one language server available for checking
+Returns a successful response when there is at least one language server available for checking.
+The respnse of his api will not contain a data body, just a 200 response code. Access to the
+"Access to monitoring API" permission is not needed to use this API.
 
 **Available since Core Platform version 2022.03**
 
@@ -6932,8 +6934,6 @@ Returns 200 when there is at least one language server available for checking
                 "status": 503
             }
         }
-
-
 
 
 # Data Structures

--- a/apiary.apib
+++ b/apiary.apib
@@ -6912,7 +6912,7 @@ A general summary of the health of the Acrolinx Platform.
           }
         }
 
-## Get Health Metrics [GET /api/v1/monitoring/health/status]
+## Get Health Status [GET /api/v1/monitoring/health/status]
 
 Returns a successful response when there is at least one language server available for checking.
 The respnse of his api will not contain a data body, just a 200 response code. Access to the
@@ -6934,7 +6934,6 @@ The respnse of his api will not contain a data body, just a 200 response code. A
                 "status": 503
             }
         }
-
 
 # Data Structures
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -6938,7 +6938,7 @@ access to the permission "Access to monitoring API" to use this API.
 
 ## Get Health Liveliness [GET /api/v1/monitoring/health/live]
 
-Returns a successful response when the server is accepting and processing web requests.
+This returns a successful response when the server can accept and process web requests.
 This does not entail that the server is ready for processing check requests. However
 making an API call to `api/v1/monitoring/health/status` will give that information.
 


### PR DESCRIPTION
Add 2 sections under **Group Monitoring API**

- Get Health Status `GET /api/v1/monitoring/health/status`
- Get Health Liveliness `GET /api/v1/monitoring/health/live`
- Add success responses
- Add error response only to health status (it can return `503`)
- Error for health life means anything you get that is not `200`

