### PR TITLE
docs: error response when external auth is enabled

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -3148,7 +3148,7 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
 
 + Response 403 (application/json)
 
-        // when external authentication is enabled, you shouldn't be able to change password through the API
+        // when external authentication is enabled, you shouldn't be able to change the password through the API
         {
             "links": {},
                 "error": {

--- a/apiary.apib
+++ b/apiary.apib
@@ -3146,6 +3146,20 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
             }
         }
 
++ Response 403 (application/json)
+
+        // when external authentication is enable you should not be able to change password through the API
+        {
+        	"links": {},
+        	"error": {
+        		"reference": "82a781cb-059a-4039-a17d-af8e20bec019",
+        		"detail": "The user is not allowed to change password.",
+        		"type": "passwordChangeForbidden",
+        		"title": "Password change is not allowed",
+        		"status": 403
+        	}
+        }
+
 + Response 404 (application/json)
 
         // when the user couldn't be identified by its *id* in the database

--- a/apiary.apib
+++ b/apiary.apib
@@ -3153,7 +3153,7 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
             "links": {},
                 "error": {
                     "reference": "82a781cb-059a-4039-a17d-af8e20bec019",
-                    "detail": "The user is not allowed to change password.",
+                    "detail": "The user isn't allowed to change the password.",
                     "type": "passwordChangeForbidden",
                     "title": "Password change is not allowed",
                     "status": 403

--- a/apiary.apib
+++ b/apiary.apib
@@ -3139,7 +3139,7 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
         {
             "links": {},
                 "error": {
-                    "detail": "The user does not have the required privileges to perform the operation.",
+                    "detail": "The user doesn't have the privileges required to perform the operation.",
                     "type": "insufficientPrivileges",
                     "title": "Insufficient privileges",
                     "status": 403

--- a/apiary.apib
+++ b/apiary.apib
@@ -3148,7 +3148,7 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
 
 + Response 403 (application/json)
 
-        // when external authentication is enable you should not be able to change password through the API
+        // when external authentication is enabled, you shouldn't be able to change password through the API
         {
             "links": {},
                 "error": {

--- a/apiary.apib
+++ b/apiary.apib
@@ -3137,12 +3137,12 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
 
         // when you don't have the privilege to update users
         {
-        "links": {},
-            "error": {
-                "detail": "The user does not have the required privileges to perform the operation.",
-                "type": "insufficientPrivileges",
-                "title": "Insufficient privileges",
-                "status": 403
+            "links": {},
+                "error": {
+                    "detail": "The user does not have the required privileges to perform the operation.",
+                    "type": "insufficientPrivileges",
+                    "title": "Insufficient privileges",
+                    "status": 403
             }
         }
 
@@ -3150,14 +3150,14 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
 
         // when external authentication is enable you should not be able to change password through the API
         {
-        	"links": {},
-        	"error": {
-        		"reference": "82a781cb-059a-4039-a17d-af8e20bec019",
-        		"detail": "The user is not allowed to change password.",
-        		"type": "passwordChangeForbidden",
-        		"title": "Password change is not allowed",
-        		"status": 403
-        	}
+            "links": {},
+                "error": {
+                    "reference": "82a781cb-059a-4039-a17d-af8e20bec019",
+                    "detail": "The user is not allowed to change password.",
+                    "type": "passwordChangeForbidden",
+                    "title": "Password change is not allowed",
+                    "status": 403
+            }
         }
 
 + Response 404 (application/json)


### PR DESCRIPTION
In this case, the external authentication system is used to manage password change