### PR TITLE
fix: Locales is an array

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -307,9 +307,7 @@ If an invalid access token was sent, the response is still a 401, though.
                 "version": "5.1.0.123",
                 "name": "Acrolinx Core Platform"
             },
-            "locales": {
-                "en"
-            }
+            "locales": [ "en" ]
           },
           "links": {
             "signIn": "https://tenant.acrolinx.cloud/api/v1/auth/sign-ins",


### PR DESCRIPTION
If you test this response example given in the document in a JSON validator it says that is invalid. The other response example above has "locales" as array. So, in this 2nd example it should be also an array.