### PR TITLE
fix: Remove content type from a Delete Role response example returns with 204

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -6539,7 +6539,7 @@ This lets you delete a specified role based on its *id*.
 
             X-Acrolinx-Auth: your_access_token
 
-+ Response 204 (application/json)
++ Response 204
 
 + Response 400 (application/json)
 


### PR DESCRIPTION
The delete role API returns with 204 (No Content) therefore the content-type (application/json) not needed there.