### PR TITLE
fix: Invalid JSON in response example for Retrieve Platform Notifications 

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -6825,19 +6825,19 @@ Retrieves active notifications from the platform.
 + Response 200 (application/json)
 
         {
-          "data":
-            {
-              "requestTimeInMilliseconds" : "1525449382",
-              "platformNotifications": [{
-              "id": "e06491e9-c67f-4da7-85da-eb30b9ca9101",
-              "title": "Important Announcement",
-              "body":  "Acrolinx Platform 5.6 will be deployed tomorrow.",
-              "importance": "high",
-              "start": 1528127782,
-              "end": 1530719782
-              }
-            ]
-          }}
+            "data": {
+                "requestTimeInMilliseconds": "1525449382",
+                "platformNotifications": [
+                    {
+                        "id": "e06491e9-c67f-4da7-85da-eb30b9ca9101",
+                        "title": "Important Announcement",
+                        "body": "Acrolinx Platform 5.6 will be deployed tomorrow.",
+                        "importance": "high",
+                        "start": 1528127782,
+                        "end": 1530719782
+                    }
+                ]
+            }
         }
 
 


### PR DESCRIPTION
The given JSON response example for the Retrieve Platform Notifications request is invalid. Removed the extra curly bracket and re-formatted the example.