### PR TITLE
fix: Use array with fixed type CustomField type specification

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -5213,7 +5213,7 @@ This shows a list of your user custom fields.
 
     + Attributes (object)
         + links (object)
-        + data (CustomField)
+        + data (array[CustomField], fixed-type)
 
     + Body
 


### PR DESCRIPTION
For the Get Custom Fields request-response example it returns with an array of CustomField type objects in the data. Also use [fixed-type](https://apiblueprint.org/documentation/mson/specification.html#353-type-attribute) in array.
