### PR TITLE
fix: Create a dictionary entry success response example

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -6772,7 +6772,7 @@ issues[n].canAddToDictionary: true
             "documentId": "283ab1e075f21a"              // required if scope=document
         }
 
-+ Response 200
++ Response 201 (application/json)
 
         {
           "data": {


### PR DESCRIPTION
Fix the provided example for Create a dictionary entry in the Dictionary API group. When a new entry has been created the success response status code is 201 and the type (application/json).