### PR TITLE
fix: Get Document by id example

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -6630,8 +6630,6 @@ This method provides Document which was found in the database.
         {
             "data": {
                 "id": "283ab1e075f21a",
-                "reference": "C:\\abc.md",
-                "contentType": "E-Mail",
                 "customFields": [
                     {
                         "displayName": "Project ID",

--- a/apiary.apib
+++ b/apiary.apib
@@ -6625,6 +6625,9 @@ Typical program flow:
 
 This method provides Document which was found in the database.
 
++ Parameters
+    + id: `99576707-ed8c-44b6-82b8-c3ced8f349d1` (string, required) - document id
+
 + Response 200 (application/json)
 
         {


### PR DESCRIPTION
Removed deleted `referennce` and `contentType` fields from response data and added missing Parameters block for define the id param.