### PR TITLE
Remove tenantId from User API examples

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1483,7 +1483,6 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                         "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                         "licenseType": "named",
                         "licenseStatus": "inactive",
-                        "tenantId": "smarttech",
                         "activeTokenId": "",
                         "checkingFrequency": "infrequent",
                         "properties" : {
@@ -1520,7 +1519,6 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                         "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                         "licenseType": "builtin",
                         "licenseStatus": "active",
-                        "tenantId": "smarttech",
                         "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
                         "checkingFrequency": "infrequent",
                         "properties" : {
@@ -1856,7 +1854,6 @@ You'll also see properties, roles, and custom fields.
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -1957,7 +1954,6 @@ This is an alternative way of getting information about the current (in request 
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -2090,7 +2086,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -2312,7 +2307,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -2536,7 +2530,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -2771,7 +2764,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -3097,7 +3089,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -3204,7 +3195,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "properties" : {
                         "customkey": "customvalue",
                     },
@@ -3347,7 +3337,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -3430,7 +3419,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -3575,7 +3563,6 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                     "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                     "licenseType": "named",
                     "licenseStatus": "inactive",
-                    "tenantId": "smarttech",
                     "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
                     "checkingFrequency": "infrequent",
                     "properties" : {
@@ -3848,7 +3835,6 @@ Returns a list of users who are missing one or more required user custom fields.
                         "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                         "licenseType": "named",
                         "licenseStatus": "inactive",
-                        "tenantId": "smarttech",
                         "activeTokenId": "",
                         "checkingFrequency": "infrequent",
                         "properties" : {
@@ -3890,7 +3876,6 @@ Returns a list of users who are missing one or more required user custom fields.
                         "lastIntegrationAccess": "1970-01-01T00:00:00Z",
                         "licenseType": "builtin",
                         "licenseStatus": "active",
-                        "tenantId": "smarttech",
                         "activeTokenId": "uqlyxi3cdxrdqn7bzwdfffyvzr",
                         "checkingFrequency": "infrequent",
                         "properties" : {
@@ -6970,7 +6955,6 @@ you'll see a response that isn't `200`.
 + lastIntegrationAccess (string) - The ISO8601 timestamp indicating when the last integration access occurred
 + licenseType (string) - Indicates the type of license as one of ['named' | 'concurrent' | 'builtin']
 + licenseStatus (string) - The license status
-+ tenantId (string) - The tenant ID
 + activeTokenId (string) - Displays the currently active API token's id or an empty string if there is no active token
 + checkingFrequency (UserStatus) - Displays a rough idea of the usage pattern of the user by checking their frequency across the lifetime of the user in days
 + properties (object) - Key/Value pair of properties


### PR DESCRIPTION
Noticed there is a tenantId field in the User API response/request examples, but in reality this API not has this field. 