### PR TITLE
Document new error messages from User API

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -1705,19 +1705,11 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
 
 + Response 400 (application/json)
 
+        // when input parameters are invalid,
+        // e.g.
         // when the sort query parameter uses an invalid field name
-        {
-            "links": {},
-            "error": {
-                "reference": "f38d5eba-c68c-4ea3-b0db-ce987a5a16f4",
-                "detail": "Invalid user sortable field",
-                "type": "client",
-                "title": "Bad Request",
-                "status": 400
-            }
-        }
-
-        // when the field name is omitted in the sort query parameter
+        // when the per_page parameter exceeds the 500 per page limit
+        // `validationDetails` describes the nature of the validation issue
         {
             "links": {},
             "error": {
@@ -1731,40 +1723,14 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                         "constraint": "Pattern",
                         "detail": "must match \"[+-]?.+\"",
                         "invalidValue": "+"
+                    },
+                    {
+                        "title": "Validation error",
+                        "constraint": "Range",
+                        "detail": "must be between 1 and 500",
+                        "invalidValue": "900"
                     }
                 ],
-                "status": 400
-            }
-        }
-
-        // when the per_page parameter exceeds the 500 per page limit
-        {
-            "links": {},
-            "error": {
-                "reference": "196f8b88-493c-46d7-b7bc-5da32d0a58d7",
-                "detail": "Check the request for invalid values or missing parameters.",
-                "type": "validation",
-                "title": "Invalid request attributes",
-                "validationDetails": [
-                {
-                    "title": "Validation error",
-                    "constraint": "Range",
-                    "detail": "must be between 1 and 500",
-                    "invalidValue": "900"
-                }
-                ],
-                "status": 400
-            }
-        }
-
-        // when the page parameter has an invalid value such as 0 or negative number
-        {
-            "links": {},
-            "error": {
-                "reference": "b2045b7f-1dce-49e7-880a-93874f427554",
-                "detail": "Invalid page request attribute, it must be greater than zero",
-                "type": "client",
-                "title": "Bad Request",
                 "status": 400
             }
         }
@@ -4147,6 +4113,30 @@ Typical use cases for this API:
                 "detail": "The user does not have the required privileges to perform the operation.",
                 "type": "insufficientPrivileges",
                 "title": "Insufficient privileges",
+                "status": 403
+            }
+        }
+
+        // when the creator or receiver of the token is the built-in `admin`
+        {
+            "links": {},
+            "error": {
+                "reference": "64311fe7-2a7e-4e3b-849e-4e9ff8651400",
+                "detail": "The built-in user `admin` mustn\'\'t create or retrieve any API tokens.",
+                "type": "insufficientPrivileges",
+                "title": "Can't Create API Token For `admin`",
+                "status": 403
+            }
+        }
+
+        // when the user tries to create a token for another user with more elevated roles
+        {
+            "links": {},
+            "error": {
+                "reference": "64311fe7-2a7e-4e3b-849e-4e9ff8651400",
+                "detail": "Operating user attempted to assign more elevated privileges than their own. This isn't allowed.",
+                "type": "insufficientPrivileges",
+                "title": "Privilege Escalation (Insufficient Privileges)",
                 "status": 403
             }
         }

--- a/apiary.apib
+++ b/apiary.apib
@@ -1705,11 +1705,26 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
 
 + Response 400 (application/json)
 
-        // when input parameters are invalid,
-        // e.g.
         // when the sort query parameter uses an invalid field name
-        // when the per_page parameter exceeds the 500 per page limit
-        // `validationDetails` describes the nature of the validation issue
+        {
+            "links": {},
+            "error": {
+                "reference": "b4c323ab-413b-4bf5-be60-93e13c3aad93",
+                "detail": "Check the request for invalid values or missing parameters.",
+                "type": "validation",
+                "title": "Couldn't parse 'sort' query parameter",
+                "validationDetails": [
+                    {
+                        "title": "Validation error",
+                        "detail": "sort param must not be null",
+                        "invalidValue": "null"
+                    }
+                ],
+                "status": 400
+            }
+        }
+
+        // when the field name is omitted in the sort query parameter
         {
             "links": {},
             "error": {
@@ -1723,14 +1738,40 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                         "constraint": "Pattern",
                         "detail": "must match \"[+-]?.+\"",
                         "invalidValue": "+"
-                    },
-                    {
-                        "title": "Validation error",
-                        "constraint": "Range",
-                        "detail": "must be between 1 and 500",
-                        "invalidValue": "900"
                     }
                 ],
+                "status": 400
+            }
+        }
+
+        // when the per_page parameter exceeds the 500 per page limit
+        {
+            "links": {},
+            "error": {
+                "reference": "196f8b88-493c-46d7-b7bc-5da32d0a58d7",
+                "detail": "Check the request for invalid values or missing parameters.",
+                "type": "validation",
+                "title": "Invalid request attributes",
+                "validationDetails": [
+                {
+                    "title": "Validation error",
+                    "constraint": "Range",
+                    "detail": "must be between 1 and 500",
+                    "invalidValue": "900"
+                }
+                ],
+                "status": 400
+            }
+        }
+
+        // when the page parameter has an invalid value such as 0 or negative number
+        {
+            "links": {},
+            "error": {
+                "reference": "b2045b7f-1dce-49e7-880a-93874f427554",
+                "detail": "Invalid page request attribute, it must be greater than zero",
+                "type": "client",
+                "title": "Bad Request",
                 "status": 400
             }
         }


### PR DESCRIPTION
Updated the docs about the latest changes relating to error messages in the User API.

The error messages haven't fundamentally changed. In most cases, the documentation still matches. 
Some `title` and `detail` fields have been localized. But since the translations are still work in progress and they're likely to change, I haven't updated the examples. The hard-coded messages are good enough and they should be the fallback anyway. 

Shortened the list of validation errors, since we were explaining all kinds of errors from validation in the code but neglected the bean validation. I think a condensed example is enough. 

Added examples of errors on token creation by/for built-in `admin` user and privilege escalation error. 