### PR TITLE
fix: Bump Ruby version 2.7.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ruby:2.6.5
+image: ruby:2.7.0
 
 workflow:
   rules:


### PR DESCRIPTION
Installing `apiaryio` with `gem install` is failing on GitLab. Suggested solution is to update the Ruby version >= 2.7.0.

Error message
```
ERROR:  Error installing apiaryio:
	The last version of domain_name (~> 0.5) to support your Ruby & RubyGems was 0.5.20190701. Try installing it with `gem install domain_name -v 0.5.20190701` and then running the current command again
	domain_name requires Ruby version >= 2.7.0. The current ruby version is 2.6.5.114.
```