### PR TITLE
Remove the comment about invalid tokens resulting in a 401 on the index/root API

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -267,7 +267,6 @@ All HTML fields only contain formatting tags that can be used without security r
 ## Index [GET /api/v1]
 
 Note: This is the only web service method that provides a 200 response if no access token was sent.
-If an invalid access token was sent, the response is still a 401, though.
 
 + Request
 


### PR DESCRIPTION
Due to a change in functionality, invalid tokens no longer result in a 401 response on the index/root API, and are instead ignored.
This updates the related docs to remove the comment about invalid tokens resulting in a 401.