### PR TITLE
Add new docs from Acrolinx One GA updates

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -7137,6 +7137,9 @@ you'll see a response that isn't `200`.
 + checkingFrequency (UserStatus) - Displays a rough idea of the usage pattern of the user by checking their frequency across the lifetime of the user in days
 + properties (object) - Key/Value pair of properties
 + roles (array[Role]) - List of assigned roles
++ idpUser (boolean) - Indicates whether the user has any linked identity providers
++ staffUser (boolean) - Indicates whether the user is an Acrolinx staff member
++ rolesSetByIdp (boolean) - Indicates whether the user has their roles managed by their identity provider
 + customFields (array[CustomField]) - List of custom fields
 
 ### UserStatus (enum)

--- a/apiary.apib
+++ b/apiary.apib
@@ -3361,6 +3361,20 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
             }
         }
 
++ Response 400 (application/json)
+
+        // when the user has their roles managed by their identity provider
+        {
+            "links": {},
+            "error": {
+                "reference": "57380cf5-7f4d-481f-9490-375c950afe9d",
+                "detail": "You cannot update this users roles, because they are managed by the user's IDP"
+                "type": "validation",
+                "title": "Cannot update roles"
+                "status": 400
+            }
+        }
+
 + Response 401 (application/json)
 
         // when the access token in the request is missing or invalid

--- a/apiary.apib
+++ b/apiary.apib
@@ -1498,6 +1498,9 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                                 "name": "Term Browser Administrator"
                             }
                         ],
+                        "idpUser": true,
+                        "staffUser": true,
+                        "rolesSetByIdp": false,
                         "customFields": [
                             {
                                 "key": "Department",
@@ -1530,6 +1533,9 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                                 "name": "Analytics Read-Only User"
                             }
                         ],
+                        "idpUser": true,
+                        "staffUser": true,
+                        "rolesSetByIdp": false,
                         "customFields": [
                             {
                                 "key": "Department",
@@ -1580,6 +1586,9 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                                 "default": false
                             }
                         ],
+                        "idpUser": true,
+                        "staffUser": true,
+                        "rolesSetByIdp": false,
                         "properties": {
                             "Segmentation.xml.DTDs": ""
                         },
@@ -1613,6 +1622,9 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                                 "default": false
                             }
                         ],
+                        "idpUser": true,
+                        "staffUser": true,
+                        "rolesSetByIdp": false,
                         "properties": {
                             "Segmentation.xml.DTDs": ""
                         },
@@ -1651,6 +1663,9 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                                 "default": false
                             }
                         ],
+                        "idpUser": true,
+                        "staffUser": true,
+                        "rolesSetByIdp": false,
                         "properties": {
                             "Segmentation.xml.DTDs": ""
                         },
@@ -1684,6 +1699,9 @@ To include more than one custom field, add `&includeCustomField={Key}` to the re
                                 "default": false
                             }
                         ],
+                        "idpUser": true,
+                        "staffUser": true,
+                        "rolesSetByIdp": false,
                         "properties": {
                             "Segmentation.xml.DTDs": ""
                         },
@@ -1886,6 +1904,9 @@ You'll also see properties, roles, and custom fields.
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": true,
+                    "staffUser": true,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -1986,6 +2007,9 @@ This is an alternative way of getting information about the current (in request 
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": true,
+                    "staffUser": true,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -2114,6 +2138,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Author"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -2343,6 +2370,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Author"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -2578,6 +2608,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -2822,6 +2855,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -3163,6 +3199,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -3267,6 +3306,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -3425,6 +3467,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -3507,6 +3552,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -3651,6 +3699,9 @@ For Core Platform versions 2021.05 to 2022.02, the following apply:
                             "name": "Term Browser Administrator"
                         }
                     ],
+                    "idpUser": false,
+                    "staffUser": false,
+                    "rolesSetByIdp": false,
                     "customFields": [
                         {
                             "key": "Department",
@@ -3921,6 +3972,9 @@ Returns a list of users who are missing one or more required user custom fields.
                                 "name": "Author"
                             }
                         ],
+                        "idpUser": false,
+                        "staffUser": false,
+                        "rolesSetByIdp": false,
                         "customFields": [
                             {
                                 "key": "Department",
@@ -3962,6 +4016,9 @@ Returns a list of users who are missing one or more required user custom fields.
                                 "name": "Analytics Read-Only User"
                             }
                         ],
+                        "idpUser": false,
+                        "staffUser": false,
+                        "rolesSetByIdp": false,
                         "customFields": [
                             {
                                 "key": "Department",


### PR DESCRIPTION
This adds:
- The new `idpUser`, `staffUser` and `rolesSetByIdp` properties to the user json.
- The 400 response when attempting to update a user's roles when they are managed by their identity provider.