### PR TITLE
fix: bump the ruby version to 3.3 and separate group for reporting API

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ruby:2.7.0
+image: ruby:3.1.2
 
 workflow:
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ruby:3.1.2
+image: ruby:3.3
 
 workflow:
   rules:

--- a/apiary.apib
+++ b/apiary.apib
@@ -7144,7 +7144,7 @@ you'll see a response that isn't `200`.
 ## RandomPassword
 + value (string) - a random, policy-compliant password
 
-# Reporting API
+# Group Reporting API
 
 The reporting API provides direct access to raw check data and raw issue data.
 You can download the data as a CSV file and add it to your preferred analysis tool.


### PR DESCRIPTION
- bump the ruby version to 3.3
- separate group for reporting API