### PR TITLE
feat: add message for empty start and end date

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -7280,6 +7280,20 @@ curl \
 
         {
             "code": 400,
+            "message": "Provide a start date."
+        } 
+
++ Response 400 (application/json)
+
+        {
+            "code": 400,
+            "message": "Provide an end date."
+        }
+
++ Response 400 (application/json)
+
+        {
+            "code": 400,
             "message": "2024-06-31 is an invalid start date. Make sure the date entered is in the format 'yyyy-MM-dd' and corresponds with the actual number of days in the month."
         } 
 
@@ -7438,6 +7452,20 @@ curl \
         "Check ID",Date,Context,Issue,"Structural context","Guideline ID","Guideline name",Language,"Issue type"
         "4bbdc491-6821-3b53-8881-001553987b69",2023-10-29,"hello woorld",woorld,sentence,"en_CONSISTENCY_Guideline_id-9","CONSISTENCY guideline id 9 display name",en,syntax
         "4bbdc491-6821-3b53-8881-001553987b69",2023-10-29,"hello woorld",woorld,sentence,"en_CONSISTENCY_Guideline_id-2","CONSISTENCY guideline id 2 display name",en,syntax
+
++ Response 400 (application/json)
+
+        {
+            "code": 400,
+            "message": "Provide a start date."
+        } 
+
++ Response 400 (application/json)
+
+        {
+            "code": 400,
+            "message": "Provide an end date."
+        }
 
 + Response 400 (application/json)
 


### PR DESCRIPTION
Revert changes to remove messages for not provided dates. This message is required to let user know that the start or end date is not provided. Add message again which is removed in last commit.
