### PR TITLE
Add example for version info about linguistic configuration

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -287,7 +287,7 @@ Note: This is the only web service method that provides a 200 response if no acc
           },
           "links": {
             "signIn": "https://tenant.acrolinx.cloud/api/v1/auth/sign-ins"
-            }
+          }
         }
 
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -268,7 +268,7 @@ All HTML fields only contain formatting tags that can be used without security r
 
 This endpoint returns general information about the current Acrolinx
 version. Starting with version 2024.09, it also contains
-information about the linguistic configuration that is installed.
+information about the installed linguistic configuration (referred to as a "guidance package").
 
 
 **Note**: This is the only web service method that provides a 200 response if no access token was sent.

--- a/apiary.apib
+++ b/apiary.apib
@@ -267,7 +267,7 @@ All HTML fields only contain formatting tags that can be used without security r
 ## Index [GET /api/v1]
 
 This endpoint returns general information about the current Acrolinx
-Platform. Starting with version 2024.09 it also contains version
+version. Starting with version 2024.09, it also contains
 information about the linguistic configuration that is installed.
 
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -266,6 +266,11 @@ All HTML fields only contain formatting tags that can be used without security r
 
 ## Index [GET /api/v1]
 
+This endpoint returns general information about the current Acrolinx
+Platform. Starting with version 2024.09 it also contains version
+information about the linguistic configuration that is installed.
+
+
 **Note**: This is the only web service method that provides a 200 response if no access token was sent.
 
 + Request

--- a/apiary.apib
+++ b/apiary.apib
@@ -283,6 +283,12 @@ Note: This is the only web service method that provides a 200 response if no acc
                 "version": "5.1.0.123",
                 "name": "Acrolinx Core Platform"
             },
+            "guidancePackage": {
+                "name": "Guidance Package for ACME",
+                "version": "2024.09",
+                "build": "7732",
+                "date": "2024-09-13"
+            },
             "locales": [ "en" ]
           },
           "links": {

--- a/apiary.apib
+++ b/apiary.apib
@@ -266,7 +266,7 @@ All HTML fields only contain formatting tags that can be used without security r
 
 ## Index [GET /api/v1]
 
-Note: This is the only web service method that provides a 200 response if no access token was sent.
+**Note**: This is the only web service method that provides a 200 response if no access token was sent.
 
 + Request
 


### PR DESCRIPTION
Up to now, the Index endpoint only returned the platform version. Starting with 2024.09 it also contains version info about the linguistic configuration that is installed for that platform.