### PR TITLE
doc: rename goal column name to goal ID

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -7325,7 +7325,7 @@ curl \
 |Context|string|Sentence or paragraph where the issue occurred|1024|
 |Issue|string|Content that Acrolinx highlighted|255|
 |Structural context|string|Structural location where the issue occurred in the file|1024|
-|Goal|string|ID of the goal|255|
+|Goal ID|string|ID of the goal|255|
 |Guideline ID|string|Unique ID of the guideline|255|
 |Guideline name|string|Name of the guideline|255|
 |Language|string|Checking language|255|


### PR DESCRIPTION
For CSV format rename goal column to 'Goal ID' because Issue messages in pulsar contains goal ID and not the goal display name.