### PR TITLE
Add description of license info

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -336,7 +336,11 @@ and order number).
                 "build": "7732",
                 "date": "2024-09-13"
             },
-            "locales": [ "en" ]
+            "locales": [ "en" ],
+            "license": { // **Since Acrolinx 2025.02**
+                "expiresAt": "2038-01-19T03:14:08Z",
+                "orderId": 1729
+            }
           },
           "links": {
             "signIn": "https://tenant.acrolinx.cloud/api/v1/auth/sign-ins"

--- a/apiary.apib
+++ b/apiary.apib
@@ -302,8 +302,11 @@ The value of the password is `backslash\quote"` in the JSON below. The special c
 ## Index [GET /api/v1]
 
 This endpoint returns general information about the current Acrolinx
-version. Starting with version 2024.09, it also contains
-information about the installed linguistic configuration (referred to as a "guidance package").
+version. Starting with version 2024.09, it also contains information
+about the installed linguistic configuration (referred to as a
+"guidance package"). Starting with version 2025.02, the response also
+yields information about the currently installed license (expiry date
+and order number).
 
 
 **Note**: This is the only web service method that provides a 200 response if no access token was sent.


### PR DESCRIPTION
To get some information about the installed license (expiry date and order ID), the API index now has a small license JSON blob that returns this info.

Addresses DEV-41487