### PR TITLE
Add link to new home for Term API

### DIFF
--- a/term-api.md
+++ b/term-api.md
@@ -1,0 +1,5 @@
+# Terminology API
+
+This document has moved and is now part of the [Platform API documentation
+hosted on
+Apiary](https://acrolinxapi.docs.apiary.io/#reference/terminology-api-v9)


### PR DESCRIPTION
Several customers still have the link to the separate Term API documentation. This PR recreates the file and points them to Apiary.