### PR TITLE
docs: add burn-after-reading note to Poll check result

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -787,6 +787,8 @@ Note that not all occurrences of an issue always have the same suggestions. When
 
 Polls the check result. Acrolinx either returns a progress response or the completed result. The URL for the request is in the "result" link of the submitted check.
 
+NOTE: To optimize server memory, check results are removed from the server immediately after they are successfully retrieved. Ensure your integration stores the result locally if needed, as a second attempt to fetch the same Check ID will result in a `404 Not Found`.
+
 If you don't want to view detailed check results, you can use `HEAD` requests to poll the check status. While the check is in progress, you'll receive the status code
 202. There will also be a `Retry-After` header with a suggested retry delay.
 


### PR DESCRIPTION
## Summary

- Adds a NOTE to the **Poll check result** (`GET`) section in `apiary.apib` warning that check results are removed from the server immediately after the first successful retrieval (200 OK).
- Without this note, developers may write integrations that fetch the result once for a status check and a second time to process the data, which will now fail with a `404 Not Found` on the second call.
- This reflects the current server behavior where check results follow a "burn after reading" policy to optimize memory.

## Context

Discovered via a customer (Avalara) whose custom non-interactive checking integration was failing because it attempted to retrieve check results more than once.

## Test plan

- [ ] Verify the note renders correctly in the Apiary documentation preview
- [ ] Confirm the note appears between the endpoint description and the `HEAD` polling guidance